### PR TITLE
Wrap the tf plan output so it is more readable in the PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ The default configuration installs the latest version of Terraform CLI and insta
 
 ```yaml
 steps:
-- uses: hashicorp/setup-terraform@v1 
+- uses: hashicorp/setup-terraform@v1
 ```
 
 A specific version of Terraform CLI can be installed.
 
 ```yaml
 steps:
-- uses: hashicorp/setup-terraform@v1 
+- uses: hashicorp/setup-terraform@v1
   with:
     terraform_version: 0.12.25
 ```
@@ -37,7 +37,7 @@ Credentials for Terraform Cloud (app.terraform.io) can be configured.
 
 ```yaml
 steps:
-- uses: hashicorp/setup-terraform@v1 
+- uses: hashicorp/setup-terraform@v1
   with:
     cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
 ```
@@ -46,7 +46,7 @@ Credentials for Terraform Enterprise can be configured.
 
 ```yaml
 steps:
-- uses: hashicorp/setup-terraform@v1 
+- uses: hashicorp/setup-terraform@v1
   with:
     cli_config_credentials_hostname: 'terraform.example.com'
     cli_config_credentials_token: ${{ secrets.TF_API_TOKEN }}
@@ -56,7 +56,7 @@ The wrapper script installation can be skipped.
 
 ```yaml
 steps:
-- uses: hashicorp/setup-terraform@v1 
+- uses: hashicorp/setup-terraform@v1
   with:
     terraform_wrapper: false
 ```
@@ -92,15 +92,17 @@ steps:
 - uses: actions/github-script@0.9.0
   if: github.event_name == 'pull_request'
   env:
-    STDOUT: "```${{ steps.plan.outputs.stdout }}```"
+    STDOUT: "```terraform\n${{ steps.plan.outputs.stdout }}```"
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     script: |
+      const output = `<details><summary>tf plan:</summary>\n\n${process.env.STDOUT}\n\n</details>`;
+
       github.issues.createComment({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: process.env.STDOUT
+        body: output
       })
 ```
 
@@ -114,17 +116,17 @@ The following inputs are supported.
 
 - `terraform_version` - (optional) The version of Terraform CLI to install. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.
 
-- `terraform_wrapper` - (optional) Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`. 
+- `terraform_wrapper` - (optional) Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
 
 ## Outputs
 
 This action does not configure any outputs directly. However, when the `terraform_wrapper` input is set to `true`, the following outputs will be available for subsequent steps that call the `terraform` binary.
 
-- `stdout` - The STDOUT stream of the call to the `terraform` binary. 
+- `stdout` - The STDOUT stream of the call to the `terraform` binary.
 
-- `stderr` - The STDERR stream of the call to the `terraform` binary. 
+- `stderr` - The STDERR stream of the call to the `terraform` binary.
 
-- `exitcode` - The exit code of the call to the `terraform` binary.. 
+- `exitcode` - The exit code of the call to the `terraform` binary..
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ This action does not configure any outputs directly. However, when the `terrafor
 
 - `stderr` - The STDERR stream of the call to the `terraform` binary.
 
-- `exitcode` - The exit code of the call to the `terraform` binary..
+- `exitcode` - The exit code of the call to the `terraform` binary.
 
 ## License
 


### PR DESCRIPTION
Add some example might be beneficial to the community.

- What I did in here is to wrap the `terraform plan` output and highlight terraform code change.
- Remove the trailing spaces (would help with copy/paste the example code)