### PR TITLE
Change Print Terraform Plan shell to python and use a multi-line string

### DIFF
--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -275,8 +275,8 @@ jobs:
       run: terraform plan 
 
     - name: Print Terraform Plan 
-      shell: bash
-      run: echo "${{ steps.plan.outputs.stdout }}"
+      shell: python
+      run: print("""${{ steps.plan.outputs.stdout }}""")
   
   terraform-run-local-no-wrapper:
     name: 'Terraform Run Local No Wrapper' 


### PR DESCRIPTION
Change shell of **Print Terraform Plan** to python and print `steps.plan.outputs.stdout ` using a multiline string as the following steps have been failing on recent PRs:

- Setup Terraform / Terraform Run Local (ubuntu-latest)
- Setup Terraform / Terraform Run Local (macos-latest)

With the following output:

```
Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform: bad substitution
```

This will be caused by `${}` being a valid shell substitution (maybe possible to correct this by putting this into single quotes too).