### PR TITLE
Update README.md example to fix escaping issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,15 +113,25 @@ steps:
   with:
     github-token: ${{ secrets.GITHUB_TOKEN }}
     script: |
+      const validate = ${{ toJson(steps.validate.outputs.stdout) }};
+      const plan = ${{ toJson(steps.plan.outputs.stdout) }};
+
       const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
       #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-      #### Terraform Validation 🤖${{ steps.validate.outputs.stdout }}
+      #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+
+      <details><summary>Show Validation</summary>
+
+      \`\`\`${validate}\`\`\`
+
+      </details>
+
       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-      
+
       <details><summary>Show Plan</summary>
-      
-      \`\`\`${process.env.PLAN}\`\`\`
-      
+
+      \`\`\`terraform\n${plan}\`\`\`
+
       </details>
       
       *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;


### PR DESCRIPTION
Sometimes (on later versions of terraform) terraform will output warnings regarding templating which include the ${} pattern. If inserted literally, as github actions does, the contents are interpreted as js which will almost always fail. To remedy this, we use toJson which produces a safely-escaped string.