### PR TITLE
Uses tool cache - skips wrapper create on hit.

### DIFF
--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -9,6 +9,9 @@ const tc = require('@actions/tool-cache');
 const io = require('@actions/io');
 const releases = require('@hashicorp/js-releases');
 
+// Constants
+const CACHE_KEY = 'terraform';
+
 // arch in [arm, x32, x64...] (https://nodejs.org/api/os.html#os_os_arch)
 // return value in [amd64, 386, arm]
 function mapArch (arch) {
@@ -28,7 +31,8 @@ function mapOS (os) {
   return mappings[os] || os;
 }
 
-async function downloadCLI (url) {
+async function downloadCLI (url, version) {
+  // Look for CLI in the cache first
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
@@ -40,7 +44,24 @@ async function downloadCLI (url) {
     throw new Error(`Unable to download Terraform from ${url}`);
   }
 
-  return pathToCLI;
+  // Cache for later
+  const cachedPath = await tc.cacheDir(pathToCLI, CACHE_KEY, version);
+  return cachedPath;
+}
+
+async function checkWrapper (pathToCLI) {
+  const exeSuffix = os.platform().startsWith('win') ? '.exe' : '';
+  const target = [pathToCLI, `terraform-bin${exeSuffix}`].join(path.sep);
+
+  core.debug('Checking for existing wrapper');
+
+  const hasWrapper = io.which(target);
+
+  if (hasWrapper) {
+    core.debug('Wrapper found, skipping creation.');
+  }
+
+  return hasWrapper;
 }
 
 async function installWrapper (pathToCLI) {
@@ -70,9 +91,6 @@ async function installWrapper (pathToCLI) {
     core.error(`Unable to copy ${source} to ${target}.`);
     throw e;
   }
-
-  // Export a new environment variable, so our wrapper can locate the binary
-  core.exportVariable('TERRAFORM_CLI_PATH', pathToCLI);
 }
 
 // Add credentials to CLI Configuration File
@@ -126,13 +144,20 @@ async function run () {
       throw new Error(`Terraform version ${version} not available for ${platform} and ${arch}`);
     }
 
-    // Download requested version
-    const pathToCLI = await downloadCLI(build.url);
+    // Check cache for requested version, then download if not present
+    let pathToCLI = tc.find(CACHE_KEY, release.version, os.arch());
+    if (!pathToCLI) {
+      pathToCLI = await downloadCLI(build.url, release.version);
+    }
 
     // Install our wrapper
-    if (wrapper) {
+    const hasWrapper = checkWrapper(pathToCLI);
+    if (wrapper && !hasWrapper) {
       await installWrapper(pathToCLI);
     }
+
+    // Export a new environment variable, so our wrapper can locate the binary
+    core.exportVariable('TERRAFORM_CLI_PATH', pathToCLI);
 
     // Add to path
     core.addPath(pathToCLI);


### PR DESCRIPTION
I noticed that this library was using the `actions/tool-cache`, which has great helpers for saving and loading from the runner cache. 

I wanted this for my own project in order to save resources on my free Github plan. I recently learned that `actions/cache` works well with `actions/tool-cache` on Github runners, so this could be useful to others as well!

The existing API is maintained. The only logic change necessary aside from checking the cache, was to skip creation of the wrapper when loading from cache (to prevent the `terraform-bin` terraform executable from being replaced with the cached wrapper script living in `terraform`).

Let me know if any further changes are necessary to integrate!