### PR TITLE
Do not fail when theres an exit-code 2

### DIFF
--- a/dist/index1.js
+++ b/dist/index1.js
@@ -3040,7 +3040,7 @@ async function checkTerraform () {
   return io.which(pathToCLI, check);
 }
 
-(async () => {
+async () => {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
@@ -3049,14 +3049,14 @@ async function checkTerraform () {
   const stderr = new OutputListener();
   const listeners = {
     stdout: stdout.listener,
-    stderr: stderr.listener
+    stderr: stderr.listener,
   };
 
   // Execute terraform and capture output
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true
+    ignoreReturnCode: true,
   };
   const exitCode = await exec(pathToCLI, args, options);
   core.debug(`Terraform exited with code ${exitCode}.`);
@@ -3065,15 +3065,21 @@ async function checkTerraform () {
   core.debug(`exitcode: ${exitCode}`);
 
   // Set outputs, result, exitcode, and stderr
-  core.setOutput('stdout', stdout.contents);
-  core.setOutput('stderr', stderr.contents);
-  core.setOutput('exitcode', exitCode.toString(10));
+  core.setOutput("stdout", stdout.contents);
+  core.setOutput("stderr", stderr.contents);
+  core.setOutput("exitcode", exitCode.toString(10));
+
+  if (exitCode === 0 || exitCode === 2) {
+    // A exitCode of 0 is considered a success
+    // An exitCode of 2 may be returned when the '-detailed-exitcode' option
+    // is passed to plan. This denotes Success with non-empty
+    // diff (changes present).
+    return;
+  }
 
   // A non-zero exitCode is considered an error
-  if (exitCode !== 0) {
-    core.setFailed(`Terraform exited with code ${exitCode}.`);
-  }
-})();
+  core.setFailed(`Terraform exited with code ${exitCode}.`);
+};
 
 })();
 

--- a/dist/index1.js
+++ b/dist/index1.js
@@ -3049,14 +3049,14 @@ async () => {
   const stderr = new OutputListener();
   const listeners = {
     stdout: stdout.listener,
-    stderr: stderr.listener,
+    stderr: stderr.listener
   };
 
   // Execute terraform and capture output
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true,
+    ignoreReturnCode: true
   };
   const exitCode = await exec(pathToCLI, args, options);
   core.debug(`Terraform exited with code ${exitCode}.`);
@@ -3065,9 +3065,9 @@ async () => {
   core.debug(`exitcode: ${exitCode}`);
 
   // Set outputs, result, exitcode, and stderr
-  core.setOutput("stdout", stdout.contents);
-  core.setOutput("stderr", stderr.contents);
-  core.setOutput("exitcode", exitCode.toString(10));
+  core.setOutput('stdout', stdout.contents);
+  core.setOutput('stderr', stderr.contents);
+  core.setOutput('exitcode', exitCode.toString(10));
 
   if (exitCode === 0 || exitCode === 2) {
     // A exitCode of 0 is considered a success

--- a/dist/index1.js
+++ b/dist/index1.js
@@ -3040,7 +3040,7 @@ async function checkTerraform () {
   return io.which(pathToCLI, check);
 }
 
-async () => {
+(async () => {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
@@ -3079,7 +3079,7 @@ async () => {
 
   // A non-zero exitCode is considered an error
   core.setFailed(`Terraform exited with code ${exitCode}.`);
-};
+})();
 
 })();
 

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -42,7 +42,8 @@ async function checkTerraform () {
   core.setOutput('exitcode', exitCode.toString(10));
 
   // A non-zero exitCode is considered an error
-  if (exitCode !== 0) {
+  // An exit-code 2 is used when the '-detailed-exitcode' option is passed to plan. this denotes Success with non-empty diff (changes present)
+  if (exitCode !== 0 || exitCode !== 2  ) {
     core.setFailed(`Terraform exited with code ${exitCode}.`);
   }
 })();

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -12,7 +12,7 @@ async function checkTerraform () {
   return io.which(pathToCLI, check);
 }
 
-async () => {
+(async () => {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
@@ -51,4 +51,4 @@ async () => {
 
   // A non-zero exitCode is considered an error
   core.setFailed(`Terraform exited with code ${exitCode}.`);
-};
+})();

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -21,14 +21,14 @@ async () => {
   const stderr = new OutputListener();
   const listeners = {
     stdout: stdout.listener,
-    stderr: stderr.listener,
+    stderr: stderr.listener
   };
 
   // Execute terraform and capture output
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true,
+    ignoreReturnCode: true
   };
   const exitCode = await exec(pathToCLI, args, options);
   core.debug(`Terraform exited with code ${exitCode}.`);
@@ -37,9 +37,9 @@ async () => {
   core.debug(`exitcode: ${exitCode}`);
 
   // Set outputs, result, exitcode, and stderr
-  core.setOutput("stdout", stdout.contents);
-  core.setOutput("stderr", stderr.contents);
-  core.setOutput("exitcode", exitCode.toString(10));
+  core.setOutput('stdout', stdout.contents);
+  core.setOutput('stderr', stderr.contents);
+  core.setOutput('exitcode', exitCode.toString(10));
 
   if (exitCode === 0 || exitCode === 2) {
     // A exitCode of 0 is considered a success

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -42,7 +42,7 @@ async function checkTerraform () {
   core.setOutput('exitcode', exitCode.toString(10));
 
   // A non-zero exitCode is considered an error
-  // An exit-code 2 is used when the '-detailed-exitcode' option is passed to plan. this denotes Success with non-empty diff (changes present)
+  // An exit-code 2 may be returned when the '-detailed-exitcode' option is passed to plan. This denotes Success with non-empty diff (changes present).
   if (exitCode !== 0 || exitCode !== 2  ) {
     core.setFailed(`Terraform exited with code ${exitCode}.`);
   }

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -12,7 +12,7 @@ async function checkTerraform () {
   return io.which(pathToCLI, check);
 }
 
-(async () => {
+async () => {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
@@ -21,14 +21,14 @@ async function checkTerraform () {
   const stderr = new OutputListener();
   const listeners = {
     stdout: stdout.listener,
-    stderr: stderr.listener
+    stderr: stderr.listener,
   };
 
   // Execute terraform and capture output
   const args = process.argv.slice(2);
   const options = {
     listeners,
-    ignoreReturnCode: true
+    ignoreReturnCode: true,
   };
   const exitCode = await exec(pathToCLI, args, options);
   core.debug(`Terraform exited with code ${exitCode}.`);
@@ -37,13 +37,18 @@ async function checkTerraform () {
   core.debug(`exitcode: ${exitCode}`);
 
   // Set outputs, result, exitcode, and stderr
-  core.setOutput('stdout', stdout.contents);
-  core.setOutput('stderr', stderr.contents);
-  core.setOutput('exitcode', exitCode.toString(10));
+  core.setOutput("stdout", stdout.contents);
+  core.setOutput("stderr", stderr.contents);
+  core.setOutput("exitcode", exitCode.toString(10));
+
+  if (exitCode === 0 || exitCode === 2) {
+    // A exitCode of 0 is considered a success
+    // An exitCode of 2 may be returned when the '-detailed-exitcode' option
+    // is passed to plan. This denotes Success with non-empty
+    // diff (changes present).
+    return;
+  }
 
   // A non-zero exitCode is considered an error
-  // An exit-code 2 may be returned when the '-detailed-exitcode' option is passed to plan. This denotes Success with non-empty diff (changes present).
-  if (exitCode !== 0 || exitCode !== 2  ) {
-    core.setFailed(`Terraform exited with code ${exitCode}.`);
-  }
-})();
+  core.setFailed(`Terraform exited with code ${exitCode}.`);
+};


### PR DESCRIPTION
This should allow plans to succeed using the terraform_wrapper functionality whenever an exit code of `2` is returned.
https://www.terraform.io/docs/cli/commands/plan.html#detailed-exitcode

- This is useful for adding custom steps in our GitHub action workflows.

**Disclaimer:** Im not a Javascript developer so Im not sure how valid the OR condition is.