### PR TITLE
Improve output for PR comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,15 @@ steps:
     script: |
       const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
       #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
-      #### Terraform Validation 🤖\`${{ steps.validate.outputs.stdout }}\`
+      #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+      <details><summary>Validation Output</summary>
+
+      \`\`\`\n
+      ${{ steps.validate.outputs.stdout }}
+      \`\`\`
+
+      </details>
+
       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
       
       <details><summary>Show Plan</summary>


### PR DESCRIPTION
The example of the complex PR comment, with status reports for each step, produces unsatisfactory results for the `validate` stage. The stdout of `terraform validate -no-color` includes a trailing newline, which breaks the backtick code block.

<img width="918" alt="Screen Shot 2021-08-19 at 11 58 24 AM" src="https://user-images.githubusercontent.com/722830/130102217-a76a84dd-32d7-4169-bce7-885255fb36ca.png">

This PR replaces `${{ steps.validate.outputs.stdout }}` with `${{ steps.validate.outcome }}` for the header, and includes a detail block with the original standard out.  This should preserve the ability to see validate errors, but makes the H4 header look nicer.

<img width="906" alt="Screen Shot 2021-08-19 at 11 58 58 AM" src="https://user-images.githubusercontent.com/722830/130102299-74403297-4ef7-46a4-9884-638d320f8e0a.png">
