### PR TITLE
docs: update existing PR comments example

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,93 @@ steps:
       })
 ```
 
+Instead of creating a new comment each time, you can also update an existing one:
+
+```yaml
+defaults:
+  run:
+    working-directory: ${{ env.tf_actions_working_dir }}
+steps:
+- uses: actions/checkout@v2
+- uses: hashicorp/setup-terraform@v1
+
+- name: Terraform fmt
+  id: fmt
+  run: terraform fmt -check
+  continue-on-error: true
+
+- name: Terraform Init
+  id: init
+  run: terraform init
+
+- name: Terraform Validate
+  id: validate
+  run: terraform validate -no-color
+
+- name: Terraform Plan
+  id: plan
+  run: terraform plan -no-color
+  continue-on-error: true
+
+- uses: actions/github-script@v6
+  if: github.event_name == 'pull_request'
+  env:
+    PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"
+  with:
+    github-token: ${{ secrets.GITHUB_TOKEN }}
+    script: |
+      // 1. Retrieve existing bot comments for the PR
+      const { data: comments } = await github.rest.issues.listComments({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        issue_number: context.issue.number,
+      })
+      const botComment = comments.find(comment => {
+        return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
+      })
+
+      // 2. Prepare format of the comment
+      const output = `#### Terraform Format and Style 🖌\`${{ steps.fmt.outcome }}\`
+      #### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
+      #### Terraform Validation 🤖\`${{ steps.validate.outcome }}\`
+      <details><summary>Validation Output</summary>
+
+      \`\`\`\n
+      ${{ steps.validate.outputs.stdout }}
+      \`\`\`
+
+      </details>
+
+      #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
+      
+      <details><summary>Show Plan</summary>
+      
+      \`\`\`\n
+      ${process.env.PLAN}
+      \`\`\`
+      
+      </details>
+      
+      *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
+      
+      // 3. If we have a comment, update it, otherwise create a new one
+      if (botComment) {
+        github.rest.issues.updateComment({
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          comment_id: botComment.id,
+          body: output
+        })
+      } else {
+        github.rest.issues.createComment({
+          issue_number: context.issue.number,
+          owner: context.repo.owner,
+          repo: context.repo.repo,
+          body: output
+        })
+      }
+```
+
 ## Inputs
 
 The action supports the following inputs:
@@ -163,7 +250,6 @@ The action supports the following inputs:
 - `terraform_wrapper` - (optional) Whether to install a wrapper to wrap subsequent calls of 
    the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs
    named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
-
 
 ## Outputs
 


### PR DESCRIPTION
Thanks for all your efforts with this github action 👏

This PR improves the example in the documentation by ensuring that the PR comment made is updated instead of creating a new comment. I realize that in some situations a new comment is desirable, however, this PR assumes that for most use cases updating an existing comment for a PR is desirable.