### PR TITLE
Fix terraform extract

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -37,6 +37,7 @@ function mapOS (os) {
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+  core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,7 +39,6 @@ async function downloadCLI (url) {
   const pathToCLIZip = await tc.downloadTool(url);
 
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  const files = await readdir(path);
   try {
     const files = await fs.readdir(pathToCLIZip);
     for (const file of files)

--- a/dist/index.js
+++ b/dist/index.js
@@ -45,8 +45,8 @@ async function downloadCLI (url) {
       core.info(file);
 
   } catch (error) {
-    core.error(err);
-    throw err;
+    core.error(error);
+    throw error;
   }
 
   core.debug('Extracting Terraform CLI zip file');

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,9 +38,10 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
+  core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
   fixedPathToCLIZip=`${pathToCLIZip}.zip`
   io.mv(pathToCLIZip,fixedPathToCLIZip)
+  core.debug(`Moved download to ${fixedPathToCLIZip}`)
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(fixedPathToCLIZip);

--- a/dist/index.js
+++ b/dist/index.js
@@ -37,7 +37,18 @@ function mapOS (os) {
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
+  const files = await readdir(path);
+  try {
+    const files = await fs.readdir(pathToCLIZip);
+    for (const file of files)
+      core.info(file);
+
+  } catch (error) {
+    core.error(err);
+    throw err;
+  }
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,7 +38,7 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  const pathToCLI = "";
+  let pathToCLI = "";
 
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,6 +40,7 @@ async function downloadCLI (url) {
 
   let pathToCLI = '';
 
+  core.debug('Extracting Terraform CLI zip file');
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
     const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
@@ -50,7 +51,6 @@ async function downloadCLI (url) {
     pathToCLI = await tc.extractZip(pathToCLIZip);
   }
 
-  core.debug('Extracting Terraform CLI zip file');
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,13 +38,19 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  fixedPathToCLIZip=`${pathToCLIZip}.zip`
-  io.mv(pathToCLIZip,fixedPathToCLIZip)
-  core.debug(`Moved download to ${fixedPathToCLIZip}`)
+  const pathToCLI = "";
+
+  if (os.platform().startsWith('win')) {
+    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
+    fixedPathToCLIZip = `${pathToCLIZip}.zip`
+    io.mv(pathToCLIZip, fixedPathToCLIZip)
+    core.debug(`Moved download to ${fixedPathToCLIZip}`)
+    pathToCLI = await tc.extractZip(fixedPathToCLIZip);
+  } else {
+    pathToCLI = await tc.extractZip(pathToCLIZip);
+  }
 
   core.debug('Extracting Terraform CLI zip file');
-  const pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -38,13 +38,13 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  let pathToCLI = "";
+  let pathToCLI = '';
 
   if (os.platform().startsWith('win')) {
-    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
-    fixedPathToCLIZip = `${pathToCLIZip}.zip`
-    io.mv(pathToCLIZip, fixedPathToCLIZip)
-    core.debug(`Moved download to ${fixedPathToCLIZip}`)
+    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
+    const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
+    io.mv(pathToCLIZip, fixedPathToCLIZip);
+    core.debug(`Moved download to ${fixedPathToCLIZip}`);
     pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   } else {
     pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/dist/index.js
+++ b/dist/index.js
@@ -39,18 +39,11 @@ async function downloadCLI (url) {
   const pathToCLIZip = await tc.downloadTool(url);
 
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  try {
-    const files = await fs.readdir(pathToCLIZip);
-    for (const file of files)
-      core.info(file);
-
-  } catch (error) {
-    core.error(error);
-    throw error;
-  }
+  fixedPathToCLIZip=`${pathToCLIZip}.zip`
+  io.mv(pathToCLIZip,fixedPathToCLIZip)
 
   core.debug('Extracting Terraform CLI zip file');
-  const pathToCLI = await tc.extractZip(pathToCLIZip);
+  const pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -34,6 +34,7 @@ async function downloadCLI (url) {
 
   let pathToCLI = '';
 
+  core.debug('Extracting Terraform CLI zip file');
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
     const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
@@ -44,7 +45,6 @@ async function downloadCLI (url) {
     pathToCLI = await tc.extractZip(pathToCLIZip);
   }
 
-  core.debug('Extracting Terraform CLI zip file');
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -31,7 +31,18 @@ function mapOS (os) {
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
+  const files = await readdir(path);
+  try {
+    const files = await fs.readdir(pathToCLIZip);
+    for (const file of files)
+      core.info(file);
+
+  } catch (error) {
+    core.error(err);
+    throw err;
+  }
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -32,13 +32,19 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  fixedPathToCLIZip=`${pathToCLIZip}.zip`
-  io.mv(pathToCLIZip,fixedPathToCLIZip)
-  core.debug(`Moved download to ${fixedPathToCLIZip}`)
+  const pathToCLI = "";
+
+  if (os.platform().startsWith('win')) {
+    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
+    fixedPathToCLIZip = `${pathToCLIZip}.zip`
+    io.mv(pathToCLIZip, fixedPathToCLIZip)
+    core.debug(`Moved download to ${fixedPathToCLIZip}`)
+    pathToCLI = await tc.extractZip(fixedPathToCLIZip);
+  } else {
+    pathToCLI = await tc.extractZip(pathToCLIZip);
+  }
 
   core.debug('Extracting Terraform CLI zip file');
-  const pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -33,7 +33,6 @@ async function downloadCLI (url) {
   const pathToCLIZip = await tc.downloadTool(url);
 
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  const files = await readdir(path);
   try {
     const files = await fs.readdir(pathToCLIZip);
     for (const file of files)

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -32,7 +32,7 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  const pathToCLI = "";
+  let pathToCLI = "";
 
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -39,8 +39,8 @@ async function downloadCLI (url) {
       core.info(file);
 
   } catch (error) {
-    core.error(err);
-    throw err;
+    core.error(error);
+    throw error;
   }
 
   core.debug('Extracting Terraform CLI zip file');

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -31,6 +31,7 @@ function mapOS (os) {
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+  core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -33,18 +33,11 @@ async function downloadCLI (url) {
   const pathToCLIZip = await tc.downloadTool(url);
 
   core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
-  try {
-    const files = await fs.readdir(pathToCLIZip);
-    for (const file of files)
-      core.info(file);
-
-  } catch (error) {
-    core.error(error);
-    throw error;
-  }
+  fixedPathToCLIZip=`${pathToCLIZip}.zip`
+  io.mv(pathToCLIZip,fixedPathToCLIZip)
 
   core.debug('Extracting Terraform CLI zip file');
-  const pathToCLI = await tc.extractZip(pathToCLIZip);
+  const pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   core.debug(`Terraform CLI path is ${pathToCLI}.`);
 
   if (!pathToCLIZip || !pathToCLI) {

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -32,9 +32,10 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  core.info(`Terraform CLI Download Path is ${pathToCLIZip}`)
+  core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
   fixedPathToCLIZip=`${pathToCLIZip}.zip`
   io.mv(pathToCLIZip,fixedPathToCLIZip)
+  core.debug(`Moved download to ${fixedPathToCLIZip}`)
 
   core.debug('Extracting Terraform CLI zip file');
   const pathToCLI = await tc.extractZip(fixedPathToCLIZip);

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -32,13 +32,13 @@ async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
 
-  let pathToCLI = "";
+  let pathToCLI = '';
 
   if (os.platform().startsWith('win')) {
-    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`)
-    fixedPathToCLIZip = `${pathToCLIZip}.zip`
-    io.mv(pathToCLIZip, fixedPathToCLIZip)
-    core.debug(`Moved download to ${fixedPathToCLIZip}`)
+    core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
+    const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
+    io.mv(pathToCLIZip, fixedPathToCLIZip);
+    core.debug(`Moved download to ${fixedPathToCLIZip}`);
     pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   } else {
     pathToCLI = await tc.extractZip(pathToCLIZip);

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -94,6 +94,8 @@ describe('Setup Terraform', () => {
       .fn()
       .mockReturnValueOnce('file.zip');
 
+    io.mv = jest.fn();
+
     tc.extractZip = jest
       .fn()
       .mockReturnValueOnce('file');


### PR DESCRIPTION
On Windows runners, extracting the downloaded CLI zip file was failing because the file didn't have a `.zip` extension. This PR attempts to solve the problem by adding the extension to the downloaded file before extraction.

(fixes #186)