### PR TITLE
Add new-style readme build badges, bump `actions/checkout` in `README.md` examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ defaults:
   run:
     working-directory: ${{ env.tf_actions_working_dir }}
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: hashicorp/setup-terraform@v2
 
 - name: Terraform fmt
@@ -148,7 +148,7 @@ defaults:
   run:
     working-directory: ${{ env.tf_actions_working_dir }}
 steps:
-- uses: actions/checkout@v2
+- uses: actions/checkout@v3
 - uses: hashicorp/setup-terraform@v2
 
 - name: Terraform fmt

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 # setup-terraform
 
-<p align="left">
-  <a href="https://github.com/hashicorp/setup-terraform/actions"><img alt="Continuous Integration" src="https://github.com/hashicorp/setup-terraform/workflows/Continuous%20Integration/badge.svg" /></a>
-  <a href="https://github.com/hashicorp/setup-terraform/actions"><img alt="Setup Terraform" src="https://github.com/hashicorp/setup-terraform/workflows/Setup%20Terraform/badge.svg" /></a>
-</p>
+[![Continuous Integration](https://github.com/hashicorp/setup-terraform/actions/workflows/continuous-integration.yml/badge.svg)](https://github.com/hashicorp/setup-terraform/actions/workflows/continuous-integration.yml)
+[![Setup Terraform](https://github.com/hashicorp/setup-terraform/actions/workflows/setup-terraform.yml/badge.svg)](https://github.com/hashicorp/setup-terraform/actions/workflows/setup-terraform.yml)
 
 The `hashicorp/setup-terraform` action is a JavaScript action that sets up Terraform CLI in your GitHub Actions workflow by:
 

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ After you've used the action, subsequent steps in the same job can run arbitrary
 
 This action can be run on `ubuntu-latest`, `windows-latest`, and `macos-latest` GitHub Actions runners. When running on `windows-latest` the shell should be set to Bash.
 
-The default configuration installs the latest version of Terraform CLI and installs the wrapper script to wrap subsequent calls to the `terraform` binary.
+The default configuration installs the latest version of Terraform CLI and installs the wrapper script to wrap subsequent calls to the `terraform` binary:
 
 ```yaml
 steps:
 - uses: hashicorp/setup-terraform@v2
 ```
 
-A specific version of Terraform CLI can be installed.
+A specific version of Terraform CLI can be installed:
 
 ```yaml
 steps:
@@ -31,7 +31,7 @@ steps:
     terraform_version: 1.1.7
 ```
 
-Credentials for Terraform Cloud ([app.terraform.io](https://app.terraform.io/)) can be configured.
+Credentials for Terraform Cloud ([app.terraform.io](https://app.terraform.io/)) can be configured:
 
 ```yaml
 steps:
@@ -59,8 +59,7 @@ steps:
     terraform_wrapper: false
 ```
 
-Subsequent steps can access outputs when the wrapper script is installed.
-
+Subsequent steps can access outputs when the wrapper script is installed:
 
 ```yaml
 steps:
@@ -123,17 +122,17 @@ steps:
       </details>
 
       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-      
+
       <details><summary>Show Plan</summary>
-      
+
       \`\`\`\n
       ${process.env.PLAN}
       \`\`\`
-      
+
       </details>
-      
+
       *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-        
+
       github.rest.issues.createComment({
         issue_number: context.issue.number,
         owner: context.repo.owner,
@@ -200,17 +199,17 @@ steps:
       </details>
 
       #### Terraform Plan 📖\`${{ steps.plan.outcome }}\`
-      
+
       <details><summary>Show Plan</summary>
-      
+
       \`\`\`\n
       ${process.env.PLAN}
       \`\`\`
-      
+
       </details>
-      
+
       *Pusher: @${{ github.actor }}, Action: \`${{ github.event_name }}\`, Working Directory: \`${{ env.tf_actions_working_dir }}\`, Workflow: \`${{ github.workflow }}\`*`;
-      
+
       // 3. If we have a comment, update it, otherwise create a new one
       if (botComment) {
         github.rest.issues.updateComment({
@@ -233,31 +232,26 @@ steps:
 
 The action supports the following inputs:
 
-- `cli_config_credentials_hostname` - (optional) The hostname of a Terraform Cloud/Enterprise instance to 
+- `cli_config_credentials_hostname` - (optional) The hostname of a Terraform Cloud/Enterprise instance to
    place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.
-
 - `cli_config_credentials_token` - (optional) The API token for a Terraform Cloud/Enterprise instance to
    place within the credentials block of the Terraform CLI configuration file.
-
 - `terraform_version` - (optional) The version of Terraform CLI to install. Instead of a full version string,
    you can also specify a constraint string (see [Semver Ranges](https://www.npmjs.com/package/semver#ranges)
    for available range specifications). Examples are: `<1.2.0`, `~1.1.0`, `1.1.7` (all three installing
    the latest available `1.1` version). Prerelease versions can be specified and a range will stay within the
    given tag such as `beta` or `rc`. If no version is given, it will default to `latest`.
-
-- `terraform_wrapper` - (optional) Whether to install a wrapper to wrap subsequent calls of 
+- `terraform_wrapper` - (optional) Whether to install a wrapper to wrap subsequent calls of
    the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs
    named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.
 
 ## Outputs
 
 This action does not configure any outputs directly. However, when you set the `terraform_wrapper` input
-to `true`, the following outputs are available for subsequent steps that call the `terraform` binary.
+to `true`, the following outputs are available for subsequent steps that call the `terraform` binary:
 
 - `stdout` - The STDOUT stream of the call to the `terraform` binary.
-
 - `stderr` - The STDERR stream of the call to the `terraform` binary.
-
 - `exitcode` - The exit code of the call to the `terraform` binary.
 
 ## License


### PR DESCRIPTION
Some quality of life things in `README.md`:

- Using the "new style" build/workflow buttons, which also links better to the action run logs under the actions tab.
- ~Added TOC to `README.md` generated with (self plug!) https://magnetikonline.github.io/markdown-toc-generate/~
- Some whitespace clean up.