### PR TITLE
Fixed `master` to `main` workflow branch triggers

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,7 +3,7 @@ name: 'Continuous Integration'
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 jobs:

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -3,7 +3,7 @@ name: 'Setup Terraform'
 on:
   push:
     branches:
-    - master
+    - main
   pull_request:
 
 defaults:


### PR DESCRIPTION
- Noted this project has now been moved from `master` to `main` as the mainline branch (yay!)
- ...but found a few places where things still reference `master`. The GitHub workflows being the most pressing (as they are not currently running in these states).
- Also removed a bit of YAML quoting that's not needed in strings.