### PR TITLE
Fix the example of how to comment on pull request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Outputs can be used in subsequent steps to comment on the pull request:
 defaults:
   run:
     working-directory: ${{ env.tf_actions_working_dir }}
+permissions:
+  pull-requests: write
 steps:
 - uses: actions/checkout@v2
 - uses: hashicorp/setup-terraform@v2
@@ -150,6 +152,8 @@ Instead of creating a new comment each time, you can also update an existing one
 defaults:
   run:
     working-directory: ${{ env.tf_actions_working_dir }}
+permissions:
+  pull-requests: write
 steps:
 - uses: actions/checkout@v2
 - uses: hashicorp/setup-terraform@v2


### PR DESCRIPTION
It doesn't work without granting permissions.
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs