### PR TITLE
`README.md` updates - direct links to license and code of conduct, updated GitHub documents link

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,11 +262,11 @@ to `true`, the following outputs are available for subsequent steps that call th
 
 ## License
 
-[Mozilla Public License v2.0](https://github.com/hashicorp/setup-terraform/blob/master/LICENSE)
+[Mozilla Public License v2.0](LICENSE)
 
 ## Code of Conduct
 
-[Code of Conduct](https://github.com/hashicorp/setup-terraform/blob/master/CODE_OF_CONDUCT.md)
+[Code of Conduct](CODE_OF_CONDUCT.md)
 
 ## Experimental Status
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The `hashicorp/setup-terraform` action is a JavaScript action that sets up Terra
 - Configuring the [Terraform CLI configuration file](https://www.terraform.io/docs/commands/cli-config.html) with a Terraform Cloud/Enterprise hostname and API token.
 - Installing a wrapper script to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
 
-After you've used the action, subsequent steps in the same job can run arbitrary Terraform commands using [the GitHub Actions `run` syntax](https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstepsrun). This allows most Terraform commands to work exactly like they do on your local command line.
+After you've used the action, subsequent steps in the same job can run arbitrary Terraform commands using [the GitHub Actions `run` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun). This allows most Terraform commands to work exactly like they do on your local command line.
 
 ## Usage
 


### PR DESCRIPTION
Teasing a few things out of what was part of #216.

- Update links to `LICENSE` and `CODE_OF_CONDUCT.md` - not only do they not need be absolute URLs, the branches they referenced were now incorrect (`master` -> `main`).
- Updated a link to GitHub's own documentation - which now all lives at https://docs.github.com/.