### PR TITLE
Improve example jobs in `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ steps:
         issue_number: context.issue.number,
       })
       const botComment = comments.find(comment => {
-        return comment.body.includes('Terraform Format and Style')
+        return comment.user.type === 'Bot' && comment.body.includes('Terraform Format and Style')
       })
 
       // 2. Prepare format of the comment


### PR DESCRIPTION
Improve the example jobs in `README.md` by:
- Making the job fail if one of the steps fails
- Show ✅/❌instead of `success`/`failure` to make it easier to see if and which step failed

This is what it looks like:
![image](https://user-images.githubusercontent.com/3015856/195374781-84431f20-6300-4030-8457-0dc9974bc188.png)
