### PR TITLE
.github/workflows: Add GitHub Release title to workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -119,6 +119,6 @@ jobs:
           sed -e "1{/# /d;}" -e "2{/^$/d;}" ${{ needs.changelog-version.outputs.version }}.md > /tmp/release-notes.txt
       - name: GH Release
         run: |
-          gh release create "${{ inputs.versionNumber }}" --notes-file /tmp/release-notes.txt
+          gh release create "${{ inputs.versionNumber }}" --notes-file /tmp/release-notes.txt --title "${{ inputs.versionNumber }}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Reference: https://github.com/hashicorp/ghaction-terraform-provider-release/issues/44

```console
$ gh release create --help
Create a new GitHub Release for a repository.

A list of asset files may be given to upload to the new release. To define a
display label for an asset, append text starting with `#` after the file name.

If a matching git tag does not yet exist, one will automatically get created
from the latest state of the default branch.
Use `--target` to point to a different branch or commit for the automatic tag creation.
Use `--verify-tag` to abort the release if the tag doesn't already exist.
To fetch the new tag locally after the release, do `git fetch --tags origin`.

To create a release from an annotated git tag, first create one locally with
git, push the tag to GitHub, then run this command.

When using automatically generated release notes, a release title will also be automatically
generated unless a title was explicitly passed. Additional release notes can be prepended to
automatically generated notes by using the notes parameter.

USAGE
  gh release create [<tag>] [<files>...]

FLAGS
      --discussion-category string   Start a discussion in the specified category
  -d, --draft                        Save the release as a draft instead of publishing it
      --generate-notes               Automatically generate title and notes for the release
      --latest                       Mark this release as "Latest" (default: automatic based on date and version)
  -n, --notes string                 Release notes
  -F, --notes-file file              Read release notes from file (use "-" to read from standard input)
      --notes-start-tag string       Tag to use as the starting point for generating release notes
  -p, --prerelease                   Mark the release as a prerelease
      --target branch                Target branch or full commit SHA (default: main branch)
  -t, --title string                 Release title
      --verify-tag                   Abort in case the git tag doesn't already exist in the remote repository
```