### PR TITLE
Fix incorrect documentation in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Outputs can be used in subsequent steps to comment on the pull request:
 >
 > Due to that limitation, you might end up with a failed workflow run even if the plan succeeded.
 >
-> Another approach is to append your plan into the $GITHUB_JOB_SUMMARY environment variable which supports markdown.
+> Another approach is to append your plan into the $GITHUB_STEP_SUMMARY environment variable which supports markdown.
 
 ```yaml
 defaults:


### PR DESCRIPTION
`GITHUB_JOB_SUMMARY` should be `GITHUB_STEP_SUMMARY` according to [Github](https://github.blog/2022-05-09-supercharging-github-actions-with-job-summaries/).