### PR TITLE
utilize .tool-versions file to resolve terraform version

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -34,6 +34,36 @@ function mapOS (os) {
   return mappings[os] || os;
 }
 
+async function resolveVersion () {
+  let version = core.getInput('terraform_version');
+
+  if (!version) {
+    version = await getToolVersions();
+  }
+
+  return version;
+}
+
+async function getToolVersions () {
+  let version = '';
+  core.debug('Attempting to infer Terraform version from .tool-versions');
+
+  if (await fs.existsSync('.tool-versions')) {
+    const contents = await fs.readFileSync('.tool-versions').toString();
+    const match = contents.match(/^terraform (\d+(\.\d+)*)/m);
+
+    if (!match) {
+      core.debug('Could not find a valid terraform version from .tool-versions');
+    } else {
+      version = match[1];
+    }
+  } else {
+    core.debug('.tool-versions does not exist');
+  }
+
+  return version;
+}
+
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
@@ -44,7 +74,7 @@ async function downloadCLI (url) {
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
     const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
-    io.mv(pathToCLIZip, fixedPathToCLIZip);
+    await io.mv(pathToCLIZip, fixedPathToCLIZip);
     core.debug(`Moved download to ${fixedPathToCLIZip}`);
     pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   } else {
@@ -124,7 +154,7 @@ credentials "${credentialsHostname}" {
 async function run () {
   try {
     // Gather GitHub Actions inputs
-    const version = core.getInput('terraform_version');
+    const version = await resolveVersion();
     const credentialsHostname = core.getInput('cli_config_credentials_hostname');
     const credentialsToken = core.getInput('cli_config_credentials_token');
     const wrapper = core.getInput('terraform_wrapper') === 'true';

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -28,6 +28,36 @@ function mapOS (os) {
   return mappings[os] || os;
 }
 
+async function resolveVersion () {
+  let version = core.getInput('terraform_version');
+
+  if (!version) {
+    version = await getToolVersions();
+  }
+
+  return version;
+}
+
+async function getToolVersions () {
+  let version = '';
+  core.debug('Attempting to infer Terraform version from .tool-versions');
+
+  if (await fs.existsSync('.tool-versions')) {
+    const contents = await fs.readFileSync('.tool-versions').toString();
+    const match = contents.match(/^terraform (\d+(\.\d+)*)/m);
+
+    if (!match) {
+      core.debug('Could not find a valid terraform version from .tool-versions');
+    } else {
+      version = match[1];
+    }
+  } else {
+    core.debug('.tool-versions does not exist');
+  }
+
+  return version;
+}
+
 async function downloadCLI (url) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
@@ -38,7 +68,7 @@ async function downloadCLI (url) {
   if (os.platform().startsWith('win')) {
     core.debug(`Terraform CLI Download Path is ${pathToCLIZip}`);
     const fixedPathToCLIZip = `${pathToCLIZip}.zip`;
-    io.mv(pathToCLIZip, fixedPathToCLIZip);
+    await io.mv(pathToCLIZip, fixedPathToCLIZip);
     core.debug(`Moved download to ${fixedPathToCLIZip}`);
     pathToCLI = await tc.extractZip(fixedPathToCLIZip);
   } else {
@@ -118,7 +148,7 @@ credentials "${credentialsHostname}" {
 async function run () {
   try {
     // Gather GitHub Actions inputs
-    const version = core.getInput('terraform_version');
+    const version = await resolveVersion();
     const credentialsHostname = core.getInput('cli_config_credentials_hostname');
     const credentialsToken = core.getInput('cli_config_credentials_token');
     const wrapper = core.getInput('terraform_wrapper') === 'true';

--- a/test/index.json
+++ b/test/index.json
@@ -176,6 +176,46 @@
                     "url": "https://releases.hashicorp.com/terraform/0.10.0/terraform_0.10.0_windows_386.zip"
                 }
             ]
+        },
+        "1.3.7": {
+            "name": "terraform",
+            "version": "1.3.7",
+            "shasums": "terraform_1.3.7_SHA256SUMS",
+            "shasums_signature": "terraform_1.3.7_SHA256SUMS.sig",
+            "builds": [
+                {
+                    "name": "terraform",
+                    "version": "1.3.7",
+                    "os": "darwin",
+                    "arch": "amd64",
+                    "filename": "terraform_1.3.7_darwin_amd64.zip",
+                    "url": "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_darwin_amd64.zip"
+                },
+                {
+                    "name": "terraform",
+                    "version": "1.3.7",
+                    "os": "linux",
+                    "arch": "386",
+                    "filename": "terraform_1.3.7_linux_386.zip",
+                    "url": "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_386.zip"
+                },
+                {
+                    "name": "terraform",
+                    "version": "1.3.7",
+                    "os": "linux",
+                    "arch": "amd64",
+                    "filename": "terraform_1.3.7_linux_amd64.zip",
+                    "url": "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_linux_amd64.zip"
+                },
+                {
+                    "name": "terraform",
+                    "version": "1.3.7",
+                    "os": "windows",
+                    "arch": "386",
+                    "filename": "terraform_1.3.7_windows_386.zip",
+                    "url": "https://releases.hashicorp.com/terraform/1.3.7/terraform_1.3.7_windows_386.zip"
+                }
+            ]
         }
     }
 }

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -156,7 +156,7 @@ describe('Setup Terraform', () => {
       .reply(200, json);
 
     const versionObj = await setup();
-    expect(versionObj.version).toEqual('0.10.0');
+    expect(versionObj.version).toEqual('1.3.7');
 
     // downloaded CLI has been added to path
     expect(core.addPath).toHaveBeenCalled();
@@ -411,6 +411,59 @@ describe('Setup Terraform', () => {
 
     const versionObj = await setup();
     expect(versionObj.version).toEqual('0.1.1');
+
+    // downloaded CLI has been added to path
+    expect(core.addPath).toHaveBeenCalled();
+    // expect credentials are in ${HOME}.terraformrc
+    const creds = await fs.readFile(`${process.env.HOME}/.terraformrc`, { encoding: 'utf8' });
+    expect(creds.indexOf(credentialsHostname)).toBeGreaterThan(-1);
+    expect(creds.indexOf(credentialsToken)).toBeGreaterThan(-1);
+  });
+
+  test('gets version from .tool-versions when version not provided', async () => {
+    const credentialsHostname = 'app.terraform.io';
+    const credentialsToken = 'asdfjkl';
+
+    fs.existsSync = jest
+      .fn()
+      .mockReturnValueOnce(true);
+
+    fs.readFileSync = jest
+      .fn()
+      .mockReturnValueOnce(`terraform 1.3.7
+golang 1.16.3
+python 3.10.11
+ruby 3.2.1
+`);
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(null)
+      .mockReturnValueOnce(credentialsHostname)
+      .mockReturnValueOnce(credentialsToken);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    const versionObj = await setup();
+    expect(versionObj.version).toEqual('1.3.7');
 
     // downloaded CLI has been added to path
     expect(core.addPath).toHaveBeenCalled();


### PR DESCRIPTION
Several other Github Actions are utilizing the ASDF [`.tool-versions`](https://asdf-vm.com/manage/configuration.html#tool-versions) file for controlling... well... tool versions. 
- The Ruby setup action [supports it](https://github.com/ruby/setup-ruby#supported-version-syntax
- NodeJS [supports it](https://github.com/actions/setup-node/blob/main/docs/advanced-usage.md#node-version-file)
- Python has an [open PR](https://github.com/actions/setup-python/pull/588) to support it
- Go has an [open PR](https://github.com/actions/setup-go/pull/376) to support it (also authored by me).

This is super rudimentary, but since `.tool-versions` is a fairly straightforward formatting option (i.e., only X.Y.Z), it seems fairly easy to add on as a potential version resolution option.

Would love feedback and modifications as this is found useful.