### PR TITLE
✨ feat(versionfile): accept versionfile

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,9 @@ inputs:
     required: false
   terraform_version:
     description: 'The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.'
-    default: 'latest'
+    required: false
+  terraform_version_file:
+    description: 'The version of Terraform CLI to install, specify the path of your terraform version file.'
     required: false
   terraform_wrapper:
     description: 'Whether or not to install a wrapper to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. Defaults to `true`.'

--- a/dist/index.js
+++ b/dist/index.js
@@ -120,11 +120,48 @@ credentials "${credentialsHostname}" {
   core.debug(`Adding credentials to ${credsFile}`);
   await fs.writeFile(credsFile, creds);
 }
+async function isVersionFileExist(versionFilePath) {
+  try {
+    await fs.access(versionFilePath);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+async function resolveVersionInput() {
+  let version = core.getInput("terraform_version");
+  const versionFileInput = core.getInput("terraform_version_file");
+  if (version && versionFileInput) {
+    core.warning(
+      "Both terraform_version and terraform_version_file inputs are specified, only terraform_version will be used"
+    );
+  }
+  if (version) {
+    return version;
+  }
+  if (versionFileInput) {
+    const versionFilePath = path.join(
+      process.env.GITHUB_WORKSPACE,
+      versionFileInput
+    );
+    const fileExists = await isVersionFileExist(versionFilePath);
+    if (!fileExists) {
+      throw new Error(
+        `The specified terraform version file at: ${versionFilePath} does not exist`
+      );
+    }
+
+    version = await fs.readFile(versionFilePath, "utf-8");
+
+    core.info(`Resolved ${versionFileInput} as ${version}`);
+  }
+  return version || "latest";
+}
 
 async function run () {
   try {
     // Gather GitHub Actions inputs
-    const version = core.getInput('terraform_version');
+    const version = await resolveVersionInput();
     const credentialsHostname = core.getInput('cli_config_credentials_hostname');
     const credentialsToken = core.getInput('cli_config_credentials_token');
     const wrapper = core.getInput('terraform_wrapper') === 'true';

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -114,11 +114,48 @@ credentials "${credentialsHostname}" {
   core.debug(`Adding credentials to ${credsFile}`);
   await fs.writeFile(credsFile, creds);
 }
+async function isVersionFileExist(versionFilePath) {
+  try {
+    await fs.access(versionFilePath);
+    return true;
+  } catch (err) {
+    return false;
+  }
+}
+async function resolveVersionInput() {
+  let version = core.getInput("terraform_version");
+  const versionFileInput = core.getInput("terraform_version_file");
+  if (version && versionFileInput) {
+    core.warning(
+      "Both terraform_version and terraform_version_file inputs are specified, only terraform_version will be used"
+    );
+  }
+  if (version) {
+    return version;
+  }
+  if (versionFileInput) {
+    const versionFilePath = path.join(
+      process.env.GITHUB_WORKSPACE,
+      versionFileInput
+    );
+    const fileExists = await isVersionFileExist(versionFilePath);
+    if (!fileExists) {
+      throw new Error(
+        `The specified terraform version file at: ${versionFilePath} does not exist`
+      );
+    }
+
+    version = await fs.readFile(versionFilePath, "utf-8");
+
+    core.info(`Resolved ${versionFileInput} as ${version}`);
+  }
+  return version || "latest";
+}
 
 async function run () {
   try {
     // Gather GitHub Actions inputs
-    const version = core.getInput('terraform_version');
+    const version = await resolveVersionInput();
     const credentialsHostname = core.getInput('cli_config_credentials_hostname');
     const credentialsToken = core.getInput('cli_config_credentials_token');
     const wrapper = core.getInput('terraform_wrapper') === 'true';


### PR DESCRIPTION
# Added input support for terraform version file

## Description
This pull request introduces a new feature to the setup-terraform action, allowing it to accept the Terraform version from a file. It addresses two previously opened issues:    #208, #298. The feature enables users to specify the desired Terraform version through a ```terraform_version_file```.

## Changes Made
- Added support for reading the Terraform version from a .terraformrc(or any terraform version) file.

## Motivation
The motivation behind this feature is to provide more flexibility in specifying the Terraform version used within GitHub Action workflows. With the addition of this feature, users can define the Terraform version in a separate file, allowing for easier management and version control of the desired version across different workflows.

## How to Use
To utilize this new feature, follow these steps:

1. Update your existing GitHub Action workflow file (*.yml) that uses setup-terraform.
2. Add a new input called ```terraform_version_file``` to the ```setup-terraform``` action, specifying the path to the file containing the desired Terraform version.
3. Commit and push the updated workflow file to your repository.
4. When the workflow runs, the setup-terraform action will read the Terraform version from the specified file and install the corresponding CLI version.

Example workflow configuration:

```yml
name: Terraform Workflow

on:
  push:
    branches:
      - main

jobs:
  terraform:
    runs-on: ubuntu-latest

    steps:
      - name: Checkout repository
        uses: actions/checkout@v2

      - name: Set up Terraform
        uses: hashicorp/setup-terraform@v2
        with:
          terraform_version_file: .terraform-version

      # Continue with the rest of your workflow steps...
```
