### PR TITLE
replace null_resource with terraform_data

### DIFF
--- a/.github/workflows/data/local/main.tf
+++ b/.github/workflows/data/local/main.tf
@@ -1,5 +1,3 @@
-resource "null_resource" "null" {
-  triggers = {
-    value = timestamp()
-  }
+resource "terraform_data" "replacement" {
+  triggers_replace = timestamp()
 }


### PR DESCRIPTION
The `terraform_data` resource type is the native `null_resource` [replacement](https://developer.hashicorp.com/terraform/language/resources/terraform-data#example-usage-null_resource-replacement).