### PR TITLE
Remove redundant shell definition

### DIFF
--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -253,6 +253,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
       run:
+        shell: bash
         working-directory: ./.github/workflows/data/local
     steps:
     - name: Checkout
@@ -282,6 +283,7 @@ jobs:
         os: [ubuntu-latest, windows-latest, macos-latest]
     defaults:
       run:
+        shell: bash
         working-directory: ./.github/workflows/data/local
     steps:
     - name: Checkout

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -1,9 +1,9 @@
-name: 'Setup Terraform'
+name: "Setup Terraform"
 
 on:
   push:
     branches:
-    - main
+      - main
   pull_request:
 
 defaults:
@@ -12,241 +12,241 @@ defaults:
 
 jobs:
   terraform-versions:
-    name: 'Terraform Versions'
+    name: "Terraform Versions"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [0.11.14, latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
+      - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+        uses: ./
+        with:
+          terraform_version: ${{ matrix['terraform-versions'] }}
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] != 'latest' }}
-      run: terraform version | grep ${{ matrix['terraform-versions']}}
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        if: ${{ matrix['terraform-versions'] != 'latest' }}
+        run: terraform version | grep ${{ matrix['terraform-versions']}}
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] == 'latest' }}
-      run: terraform version | grep 'Terraform v'
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        if: ${{ matrix['terraform-versions'] == 'latest' }}
+        run: terraform version | grep 'Terraform v'
 
   terraform-versions-no-wrapper:
-    name: 'Terraform Versions No Wrapper'
+    name: "Terraform Versions No Wrapper"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [0.11.14, latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-        terraform_wrapper: false
+      - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+        uses: ./
+        with:
+          terraform_version: ${{ matrix['terraform-versions'] }}
+          terraform_wrapper: false
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] != 'latest' }}
-      run: terraform version | grep ${{ matrix['terraform-versions']}}
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        if: ${{ matrix['terraform-versions'] != 'latest' }}
+        run: terraform version | grep ${{ matrix['terraform-versions']}}
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] == 'latest' }}
-      run: terraform version | grep 'Terraform v'
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        if: ${{ matrix['terraform-versions'] == 'latest' }}
+        run: terraform version | grep 'Terraform v'
 
   terraform-versions-constraints:
-    name: 'Terraform Versions Constraints'
+    name: "Terraform Versions Constraints"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [~0.12, 0.12.x, <0.13.0]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
+      - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+        uses: ./
+        with:
+          terraform_version: ${{ matrix['terraform-versions'] }}
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      run: terraform version | grep 'Terraform v0\.12'
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        run: terraform version | grep 'Terraform v0\.12'
 
   terraform-versions-constraints-no-wrapper:
-    name: 'Terraform Versions Constraints No Wrapper'
+    name: "Terraform Versions Constraints No Wrapper"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [~0.12, 0.12.x, <0.13.0]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-        terraform_wrapper: false
+      - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+        uses: ./
+        with:
+          terraform_version: ${{ matrix['terraform-versions'] }}
+          terraform_wrapper: false
 
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      run: terraform version | grep 'Terraform v0\.12'
+      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+        run: terraform version | grep 'Terraform v0\.12'
 
   terraform-credentials-cloud:
-    name: 'Terraform Cloud Credentials'
+    name: "Terraform Cloud Credentials"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      TF_CLOUD_API_TOKEN: "XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
-      with:
-        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+      - name: Setup Terraform
+        uses: ./
+        with:
+          cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
 
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
-        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+      - name: Validate Terraform Credentials (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
+          cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
-        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+      - name: Validate Teraform Credentials (Linux & macOS)
+        if: runner.os != 'Windows'
+        run: |
+          cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
+          cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
   terraform-credentials-enterprise:
-    name: 'Terraform Enterprise Credentials'
+    name: "Terraform Enterprise Credentials"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+      TF_CLOUD_API_TOKEN: "XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
-      with:
-        cli_config_credentials_hostname: 'terraform.example.com'
-        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+      - name: Setup Terraform
+        uses: ./
+        with:
+          cli_config_credentials_hostname: "terraform.example.com"
+          cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
 
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
-        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+      - name: Validate Terraform Credentials (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
+          cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
-        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+      - name: Validate Teraform Credentials (Linux & macOS)
+        if: runner.os != 'Windows'
+        run: |
+          cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
+          cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
   terraform-credentials-none:
-    name: 'Terraform No Credentials'
+    name: "Terraform No Credentials"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
+      - name: Setup Terraform
+        uses: ./
 
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        [[ -f ${APPDATA}/terraform.rc ]] || exit 0
+      - name: Validate Terraform Credentials (Windows)
+        if: runner.os == 'Windows'
+        run: |
+          [[ -f ${APPDATA}/terraform.rc ]] || exit 0
 
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        [[ -f ${HOME}/.terraformrc ]] || exit 0
+      - name: Validate Teraform Credentials (Linux & macOS)
+        if: runner.os != 'Windows'
+        run: |
+          [[ -f ${HOME}/.terraformrc ]] || exit 0
 
   terraform-arguments:
-    name: 'Terraform Arguments'
+    name: "Terraform Arguments"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
+      - name: Setup Terraform
+        uses: ./
 
-    - name: Check No Arguments
-      run: terraform || exit 0
+      - name: Check No Arguments
+        run: terraform || exit 0
 
-    - name: Check Single Argument
-      run: terraform help || exit 0
+      - name: Check Single Argument
+        run: terraform help || exit 0
 
-    - name: Check Single Argument Hyphen
-      run: terraform -help
+      - name: Check Single Argument Hyphen
+        run: terraform -help
 
-    - name: Check Single Argument Double Hyphen
-      run: terraform --help
+      - name: Check Single Argument Double Hyphen
+        run: terraform --help
 
-    - name: Check Single Argument Subcommand
-      run: terraform fmt -check
+      - name: Check Single Argument Subcommand
+        run: terraform fmt -check
 
-    - name: Check Multiple Arguments Subcommand
-      run: terraform fmt -check -list=true -no-color
+      - name: Check Multiple Arguments Subcommand
+        run: terraform fmt -check -list=true -no-color
 
   terraform-arguments-no-wrapper:
-    name: 'Terraform Arguments No Wrapper'
+    name: "Terraform Arguments No Wrapper"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: false
+      - name: Setup Terraform
+        uses: ./
+        with:
+          terraform_wrapper: false
 
-    - name: Check No Arguments
-      run: terraform || exit 0
+      - name: Check No Arguments
+        run: terraform || exit 0
 
-    - name: Check Single Argument
-      run: terraform help || exit 0
+      - name: Check Single Argument
+        run: terraform help || exit 0
 
-    - name: Check Single Argument Hyphen
-      run: terraform -help
+      - name: Check Single Argument Hyphen
+        run: terraform -help
 
-    - name: Check Single Argument Double Hyphen
-      run: terraform --help
+      - name: Check Single Argument Double Hyphen
+        run: terraform --help
 
-    - name: Check Single Argument Subcommand
-      run: terraform fmt -check
+      - name: Check Single Argument Subcommand
+        run: terraform fmt -check
 
-    - name: Check Multiple Arguments Subcommand
-      run: terraform fmt -check -list=true -no-color
+      - name: Check Multiple Arguments Subcommand
+        run: terraform fmt -check -list=true -no-color
 
   terraform-run-local:
-    name: 'Terraform Run Local'
+    name: "Terraform Run Local"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -255,31 +255,27 @@ jobs:
       run:
         working-directory: ./.github/workflows/data/local
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
+      - name: Setup Terraform
+        uses: ./
 
-    - name: Terraform Init
-      shell: bash
-      run: terraform init
+      - name: Terraform Init
+        run: terraform init
 
-    - name: Terraform Format
-      shell: bash
-      run: terraform fmt -check
+      - name: Terraform Format
+        run: terraform fmt -check
 
-    - name: Terraform Plan
-      id: plan
-      shell: bash
-      run: terraform plan
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan
 
-    - name: Print Terraform Plan
-      shell: bash
-      run: echo "${{ steps.plan.outputs.stdout }}"
+      - name: Print Terraform Plan
+        run: echo "${{ steps.plan.outputs.stdout }}"
 
   terraform-run-local-no-wrapper:
-    name: 'Terraform Run Local No Wrapper'
+    name: "Terraform Run Local No Wrapper"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -288,23 +284,20 @@ jobs:
       run:
         working-directory: ./.github/workflows/data/local
     steps:
-    - name: Checkout
-      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: false
+      - name: Setup Terraform
+        uses: ./
+        with:
+          terraform_wrapper: false
 
-    - name: Terraform Init
-      shell: bash
-      run: terraform init
+      - name: Terraform Init
+        run: terraform init
 
-    - name: Terraform Format
-      shell: bash
-      run: terraform fmt -check
+      - name: Terraform Format
+        run: terraform fmt -check
 
-    - name: Terraform Plan
-      id: plan
-      shell: bash
-      run: terraform plan
+      - name: Terraform Plan
+        id: plan
+        run: terraform plan

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -1,9 +1,9 @@
-name: "Setup Terraform"
+name: 'Setup Terraform'
 
 on:
   push:
     branches:
-      - main
+    - main
   pull_request:
 
 defaults:
@@ -12,241 +12,241 @@ defaults:
 
 jobs:
   terraform-versions:
-    name: "Terraform Versions"
+    name: 'Terraform Versions'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [0.11.14, latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-        uses: ./
-        with:
-          terraform_version: ${{ matrix['terraform-versions'] }}
+    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        if: ${{ matrix['terraform-versions'] != 'latest' }}
-        run: terraform version | grep ${{ matrix['terraform-versions']}}
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] != 'latest' }}
+      run: terraform version | grep ${{ matrix['terraform-versions']}}
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        if: ${{ matrix['terraform-versions'] == 'latest' }}
-        run: terraform version | grep 'Terraform v'
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] == 'latest' }}
+      run: terraform version | grep 'Terraform v'
 
   terraform-versions-no-wrapper:
-    name: "Terraform Versions No Wrapper"
+    name: 'Terraform Versions No Wrapper'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [0.11.14, latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-        uses: ./
-        with:
-          terraform_version: ${{ matrix['terraform-versions'] }}
-          terraform_wrapper: false
+    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+        terraform_wrapper: false
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        if: ${{ matrix['terraform-versions'] != 'latest' }}
-        run: terraform version | grep ${{ matrix['terraform-versions']}}
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] != 'latest' }}
+      run: terraform version | grep ${{ matrix['terraform-versions']}}
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        if: ${{ matrix['terraform-versions'] == 'latest' }}
-        run: terraform version | grep 'Terraform v'
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] == 'latest' }}
+      run: terraform version | grep 'Terraform v'
 
   terraform-versions-constraints:
-    name: "Terraform Versions Constraints"
+    name: 'Terraform Versions Constraints'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [~0.12, 0.12.x, <0.13.0]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-        uses: ./
-        with:
-          terraform_version: ${{ matrix['terraform-versions'] }}
+    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        run: terraform version | grep 'Terraform v0\.12'
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      run: terraform version | grep 'Terraform v0\.12'
 
   terraform-versions-constraints-no-wrapper:
-    name: "Terraform Versions Constraints No Wrapper"
+    name: 'Terraform Versions Constraints No Wrapper'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
         terraform-versions: [~0.12, 0.12.x, <0.13.0]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-        uses: ./
-        with:
-          terraform_version: ${{ matrix['terraform-versions'] }}
-          terraform_wrapper: false
+    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+        terraform_wrapper: false
 
-      - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-        run: terraform version | grep 'Terraform v0\.12'
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      run: terraform version | grep 'Terraform v0\.12'
 
   terraform-credentials-cloud:
-    name: "Terraform Cloud Credentials"
+    name: 'Terraform Cloud Credentials'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      TF_CLOUD_API_TOKEN: "XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
-        with:
-          cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+    - name: Setup Terraform
+      uses: ./
+      with:
+        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
 
-      - name: Validate Terraform Credentials (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
-          cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
+        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
-      - name: Validate Teraform Credentials (Linux & macOS)
-        if: runner.os != 'Windows'
-        run: |
-          cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
-          cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
+        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
   terraform-credentials-enterprise:
-    name: "Terraform Enterprise Credentials"
+    name: 'Terraform Enterprise Credentials'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     env:
-      TF_CLOUD_API_TOKEN: "XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
-        with:
-          cli_config_credentials_hostname: "terraform.example.com"
-          cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+    - name: Setup Terraform
+      uses: ./
+      with:
+        cli_config_credentials_hostname: 'terraform.example.com'
+        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
 
-      - name: Validate Terraform Credentials (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
-          cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
+        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
-      - name: Validate Teraform Credentials (Linux & macOS)
-        if: runner.os != 'Windows'
-        run: |
-          cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
-          cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
+        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
 
   terraform-credentials-none:
-    name: "Terraform No Credentials"
+    name: 'Terraform No Credentials'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
+    - name: Setup Terraform
+      uses: ./
 
-      - name: Validate Terraform Credentials (Windows)
-        if: runner.os == 'Windows'
-        run: |
-          [[ -f ${APPDATA}/terraform.rc ]] || exit 0
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        [[ -f ${APPDATA}/terraform.rc ]] || exit 0
 
-      - name: Validate Teraform Credentials (Linux & macOS)
-        if: runner.os != 'Windows'
-        run: |
-          [[ -f ${HOME}/.terraformrc ]] || exit 0
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        [[ -f ${HOME}/.terraformrc ]] || exit 0
 
   terraform-arguments:
-    name: "Terraform Arguments"
+    name: 'Terraform Arguments'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
+    - name: Setup Terraform
+      uses: ./
 
-      - name: Check No Arguments
-        run: terraform || exit 0
+    - name: Check No Arguments
+      run: terraform || exit 0
 
-      - name: Check Single Argument
-        run: terraform help || exit 0
+    - name: Check Single Argument
+      run: terraform help || exit 0
 
-      - name: Check Single Argument Hyphen
-        run: terraform -help
+    - name: Check Single Argument Hyphen
+      run: terraform -help
 
-      - name: Check Single Argument Double Hyphen
-        run: terraform --help
+    - name: Check Single Argument Double Hyphen
+      run: terraform --help
 
-      - name: Check Single Argument Subcommand
-        run: terraform fmt -check
+    - name: Check Single Argument Subcommand
+      run: terraform fmt -check
 
-      - name: Check Multiple Arguments Subcommand
-        run: terraform fmt -check -list=true -no-color
+    - name: Check Multiple Arguments Subcommand
+      run: terraform fmt -check -list=true -no-color
 
   terraform-arguments-no-wrapper:
-    name: "Terraform Arguments No Wrapper"
+    name: 'Terraform Arguments No Wrapper'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
-        with:
-          terraform_wrapper: false
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: false
 
-      - name: Check No Arguments
-        run: terraform || exit 0
+    - name: Check No Arguments
+      run: terraform || exit 0
 
-      - name: Check Single Argument
-        run: terraform help || exit 0
+    - name: Check Single Argument
+      run: terraform help || exit 0
 
-      - name: Check Single Argument Hyphen
-        run: terraform -help
+    - name: Check Single Argument Hyphen
+      run: terraform -help
 
-      - name: Check Single Argument Double Hyphen
-        run: terraform --help
+    - name: Check Single Argument Double Hyphen
+      run: terraform --help
 
-      - name: Check Single Argument Subcommand
-        run: terraform fmt -check
+    - name: Check Single Argument Subcommand
+      run: terraform fmt -check
 
-      - name: Check Multiple Arguments Subcommand
-        run: terraform fmt -check -list=true -no-color
+    - name: Check Multiple Arguments Subcommand
+      run: terraform fmt -check -list=true -no-color
 
   terraform-run-local:
-    name: "Terraform Run Local"
+    name: 'Terraform Run Local'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -255,27 +255,27 @@ jobs:
       run:
         working-directory: ./.github/workflows/data/local
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
+    - name: Setup Terraform
+      uses: ./
 
-      - name: Terraform Init
-        run: terraform init
+    - name: Terraform Init
+      run: terraform init
 
-      - name: Terraform Format
-        run: terraform fmt -check
+    - name: Terraform Format
+      run: terraform fmt -check
 
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan
 
-      - name: Print Terraform Plan
-        run: echo "${{ steps.plan.outputs.stdout }}"
+    - name: Print Terraform Plan
+      run: echo "${{ steps.plan.outputs.stdout }}"
 
   terraform-run-local-no-wrapper:
-    name: "Terraform Run Local No Wrapper"
+    name: 'Terraform Run Local No Wrapper'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -284,20 +284,20 @@ jobs:
       run:
         working-directory: ./.github/workflows/data/local
     steps:
-      - name: Checkout
-        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+    - name: Checkout
+      uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
-      - name: Setup Terraform
-        uses: ./
-        with:
-          terraform_wrapper: false
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: false
 
-      - name: Terraform Init
-        run: terraform init
+    - name: Terraform Init
+      run: terraform init
 
-      - name: Terraform Format
-        run: terraform fmt -check
+    - name: Terraform Format
+      run: terraform fmt -check
 
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan


### PR DESCRIPTION
Remove `shell: bash` from all jobs' steps since `defaults: run: shell: bash` has already been defined at the [top of the file](https://github.com/hashicorp/setup-terraform/compare/main...rdhar:setup-terraform:patch-1#diff-1c00228f84c2234bd6f3fd35eb6745ca9effb272abb50d7a48dcc7a8b4fd64e0L10-R11), which applies to all jobs in the workflow [per documentation](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#defaultsrun).