### PR TITLE
update actions/checkout to v4

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ defaults:
 permissions:
   pull-requests: write
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: hashicorp/setup-terraform@v3
 
 - name: Terraform fmt
@@ -158,7 +158,7 @@ defaults:
 permissions:
   pull-requests: write
 steps:
-- uses: actions/checkout@v3
+- uses: actions/checkout@v4
 - uses: hashicorp/setup-terraform@v3
 
 - name: Terraform fmt


### PR DESCRIPTION
**Description:**
Thanks for your work. The actions/checkout has been [released to v4](https://github.com/actions/checkout/releases/tag/v4.0.0), I have updated README to use it.