### PR TITLE
Remove husky tool + fix lint error

### DIFF
--- a/dist/index1.js
+++ b/dist/index1.js
@@ -27222,7 +27222,7 @@ async function checkTerraform () {
   const options = {
     listeners,
     ignoreReturnCode: true,
-    silent: true, // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
+    silent: true // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
       },
       "devDependencies": {
         "@vercel/ncc": "^0.38.1",
-        "husky": "^8.0.3",
         "jest": "^29.7.0",
         "nock": "^13.5.1",
         "semistandard": "^17.0.0"
@@ -3656,21 +3655,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.17.0"
-      }
-    },
-    "node_modules/husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
-      "dev": true,
-      "bin": {
-        "husky": "lib/bin.js"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -9489,12 +9473,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "dev": true
-    },
-    "husky": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/husky/-/husky-8.0.3.tgz",
-      "integrity": "sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==",
       "dev": true
     },
     "ignore": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "test": "semistandard --env jest && jest --coverage",
     "lint": "semistandard --env jest --fix",
     "build": "ncc build wrapper/terraform.js --out wrapper/dist && ncc build index.js --out dist",
-    "prepare": "husky install",
     "format-check": "echo \"unimplemented for actions/reusable-workflows basic-validation\""
   },
   "keywords": [],
@@ -28,7 +27,6 @@
   },
   "devDependencies": {
     "@vercel/ncc": "^0.38.1",
-    "husky": "^8.0.3",
     "jest": "^29.7.0",
     "nock": "^13.5.1",
     "semistandard": "^17.0.0"

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -34,7 +34,7 @@ async function checkTerraform () {
   const options = {
     listeners,
     ignoreReturnCode: true,
-    silent: true, // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
+    silent: true // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
 


### PR DESCRIPTION
Closes #391 

Since we already have CI that runs on PR, Husky isn't really necessary 👍🏻 . This PR also fixes a linting error from `semistandard` that was resulting in our tests not running locally 🙃 

