### PR TITLE
Escape backticks in stdout and stderr

### DIFF
--- a/dist/index1.js
+++ b/dist/index1.js
@@ -27398,7 +27398,8 @@ class OutputListener {
   get contents () {
     return this._buff
       .map(chunk => chunk.toString())
-      .join('');
+      .join('')
+      .replace(/`/g, '\\`');
   }
 }
 

--- a/wrapper/lib/output-listener.js
+++ b/wrapper/lib/output-listener.js
@@ -34,7 +34,8 @@ class OutputListener {
   get contents () {
     return this._buff
       .map(chunk => chunk.toString())
-      .join('');
+      .join('')
+      .replace(/`/g, '\\`');
   }
 }
 

--- a/wrapper/test/output-listener.test.js
+++ b/wrapper/test/output-listener.test.js
@@ -14,4 +14,13 @@ describe('output-listener', () => {
     listen(Buffer.from('baz'));
     expect(listener.contents).toEqual('foobarbaz');
   });
+
+  it('escape backticks', () => {
+    const listener = new OutputListener();
+    const listen = listener.listener;
+    listen(Buffer.from('foo'));
+    listen(Buffer.from('`bar`'));
+    listen(Buffer.from('baz'));
+    expect(listener.contents).toEqual('foo\\`bar\\`baz');
+  });
 });


### PR DESCRIPTION
Thank you for an awesome actions! 😄
fixes #401

The stdout of validate or plan may contain backticks. If backticks are included, problems like #401 will occur.

Fix this problem by escaping the backticks.