### PR TITLE
wrapper: Write stdout/stderr data to stream when received

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240425-104731.yaml
+++ b/.changes/unreleased/BUG FIXES-20240425-104731.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: 'wrapper: Fix wrapper to output to stdout and stderr immediately when data is
+  received'
+time: 2024-04-25T10:47:31.19951-04:00
+custom:
+  Issue: "395"

--- a/.github/workflows/data/delay/main.tf
+++ b/.github/workflows/data/delay/main.tf
@@ -1,0 +1,11 @@
+resource "null_resource" "previous" {}
+
+resource "time_sleep" "wait_30_seconds" {
+  depends_on = [null_resource.previous]
+
+  create_duration = "30s"
+}
+
+resource "null_resource" "next" {
+  depends_on = [time_sleep.wait_30_seconds]
+}

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -11,364 +11,364 @@ defaults:
     shell: bash
 
 jobs:
-  terraform-versions:
-    name: 'Terraform Versions'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        terraform-versions: [0.11.14, latest]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] != 'latest' }}
-      run: terraform version | grep ${{ matrix['terraform-versions']}}
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] == 'latest' }}
-      run: terraform version | grep 'Terraform v'
-
-  terraform-versions-no-wrapper:
-    name: 'Terraform Versions No Wrapper'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        terraform-versions: [0.11.14, latest]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-        terraform_wrapper: false
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] != 'latest' }}
-      run: terraform version | grep ${{ matrix['terraform-versions']}}
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      if: ${{ matrix['terraform-versions'] == 'latest' }}
-      run: terraform version | grep 'Terraform v'
-
-  terraform-versions-constraints:
-    name: 'Terraform Versions Constraints'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        terraform-versions: [~0.12, 0.12.x, <0.13.0]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      run: terraform version | grep 'Terraform v0\.12'
-
-  terraform-versions-constraints-no-wrapper:
-    name: 'Terraform Versions Constraints No Wrapper'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-        terraform-versions: [~0.12, 0.12.x, <0.13.0]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-      uses: ./
-      with:
-        terraform_version: ${{ matrix['terraform-versions'] }}
-        terraform_wrapper: false
-
-    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-      run: terraform version | grep 'Terraform v0\.12'
-
-  terraform-credentials-cloud:
-    name: 'Terraform Cloud Credentials'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    env:
-      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
-
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
-        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
-        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  terraform-credentials-enterprise:
-    name: 'Terraform Enterprise Credentials'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    env:
-      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        cli_config_credentials_hostname: 'terraform.example.com'
-        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
-
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
-        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
-        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  terraform-credentials-none:
-    name: 'Terraform No Credentials'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-
-    - name: Validate Terraform Credentials (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        [[ -f ${APPDATA}/terraform.rc ]] || exit 0
-
-    - name: Validate Teraform Credentials (Linux & macOS)
-      if: runner.os != 'Windows'
-      run: |
-        [[ -f ${HOME}/.terraformrc ]] || exit 0
-
-  terraform-arguments:
-    name: 'Terraform Arguments'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-
-    - name: Check No Arguments
-      run: terraform || exit 0
-
-    - name: Check Single Argument
-      run: terraform help || exit 0
-
-    - name: Check Single Argument Hyphen
-      run: terraform -help
-
-    - name: Check Single Argument Double Hyphen
-      run: terraform --help
-
-    - name: Check Single Argument Subcommand
-      run: terraform fmt -check
-
-    - name: Check Multiple Arguments Subcommand
-      run: terraform fmt -check -list=true -no-color
-
-  terraform-arguments-no-wrapper:
-    name: 'Terraform Arguments No Wrapper'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: false
-
-    - name: Check No Arguments
-      run: terraform || exit 0
-
-    - name: Check Single Argument
-      run: terraform help || exit 0
-
-    - name: Check Single Argument Hyphen
-      run: terraform -help
-
-    - name: Check Single Argument Double Hyphen
-      run: terraform --help
-
-    - name: Check Single Argument Subcommand
-      run: terraform fmt -check
-
-    - name: Check Multiple Arguments Subcommand
-      run: terraform fmt -check -list=true -no-color
-
-  terraform-run-local:
-    name: 'Terraform Run Local'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./.github/workflows/data/local
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-
-    - name: Terraform Init
-      run: terraform init
-
-    - name: Terraform Format
-      run: terraform fmt -check
-
-    - name: Terraform Plan
-      id: plan
-      run: terraform plan
-
-    - name: Print Terraform Plan
-      run: echo "${{ steps.plan.outputs.stdout }}"
-
-  terraform-run-local-no-wrapper:
-    name: 'Terraform Run Local No Wrapper'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./.github/workflows/data/local
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: false
-
-    - name: Terraform Init
-      run: terraform init
-
-    - name: Terraform Format
-      run: terraform fmt -check
-
-    - name: Terraform Plan
-      id: plan
-      run: terraform plan
-
-  terraform-stdout-wrapper:
-    name: 'Terraform STDOUT'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./.github/workflows/data/local
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: true
-
-    - name: Terraform Init
-      run: terraform init
-
-    - name: Terraform Format
-      run: terraform fmt -check
-
-    - name: Terraform Apply
-      id: apply
-      run: terraform apply -auto-approve
-
-    - name: Terraform Output to JQ
-      id: output
-      run: terraform output -json | jq '.pet.value'
-
-  terraform-stdout-no-wrapper:
-    name: 'Terraform STDOUT No Wrapper'
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
-    defaults:
-      run:
-        shell: bash
-        working-directory: ./.github/workflows/data/local
-    steps:
-    - name: Checkout
-      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-    - name: Setup Terraform
-      uses: ./
-      with:
-        terraform_wrapper: false
-
-    - name: Terraform Init
-      run: terraform init
-
-    - name: Terraform Format
-      run: terraform fmt -check
-
-    - name: Terraform Apply
-      id: apply
-      run: terraform apply -auto-approve
-
-    - name: Terraform Output to JQ
-      id: output
-      run: terraform output -json | jq '.pet.value'
+  # terraform-versions:
+  #   name: 'Terraform Versions'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       terraform-versions: [0.11.14, latest]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+  #     uses: ./
+  #     with:
+  #       terraform_version: ${{ matrix['terraform-versions'] }}
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     if: ${{ matrix['terraform-versions'] != 'latest' }}
+  #     run: terraform version | grep ${{ matrix['terraform-versions']}}
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     if: ${{ matrix['terraform-versions'] == 'latest' }}
+  #     run: terraform version | grep 'Terraform v'
+
+  # terraform-versions-no-wrapper:
+  #   name: 'Terraform Versions No Wrapper'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       terraform-versions: [0.11.14, latest]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+  #     uses: ./
+  #     with:
+  #       terraform_version: ${{ matrix['terraform-versions'] }}
+  #       terraform_wrapper: false
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     if: ${{ matrix['terraform-versions'] != 'latest' }}
+  #     run: terraform version | grep ${{ matrix['terraform-versions']}}
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     if: ${{ matrix['terraform-versions'] == 'latest' }}
+  #     run: terraform version | grep 'Terraform v'
+
+  # terraform-versions-constraints:
+  #   name: 'Terraform Versions Constraints'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       terraform-versions: [~0.12, 0.12.x, <0.13.0]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+  #     uses: ./
+  #     with:
+  #       terraform_version: ${{ matrix['terraform-versions'] }}
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     run: terraform version | grep 'Terraform v0\.12'
+
+  # terraform-versions-constraints-no-wrapper:
+  #   name: 'Terraform Versions Constraints No Wrapper'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #       terraform-versions: [~0.12, 0.12.x, <0.13.0]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+  #     uses: ./
+  #     with:
+  #       terraform_version: ${{ matrix['terraform-versions'] }}
+  #       terraform_wrapper: false
+
+  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+  #     run: terraform version | grep 'Terraform v0\.12'
+
+  # terraform-credentials-cloud:
+  #   name: 'Terraform Cloud Credentials'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   env:
+  #     TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+
+  #   - name: Validate Terraform Credentials (Windows)
+  #     if: runner.os == 'Windows'
+  #     run: |
+  #       cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
+  #       cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  #   - name: Validate Teraform Credentials (Linux & macOS)
+  #     if: runner.os != 'Windows'
+  #     run: |
+  #       cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
+  #       cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  # terraform-credentials-enterprise:
+  #   name: 'Terraform Enterprise Credentials'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   env:
+  #     TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       cli_config_credentials_hostname: 'terraform.example.com'
+  #       cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+
+  #   - name: Validate Terraform Credentials (Windows)
+  #     if: runner.os == 'Windows'
+  #     run: |
+  #       cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
+  #       cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  #   - name: Validate Teraform Credentials (Linux & macOS)
+  #     if: runner.os != 'Windows'
+  #     run: |
+  #       cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
+  #       cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  # terraform-credentials-none:
+  #   name: 'Terraform No Credentials'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+
+  #   - name: Validate Terraform Credentials (Windows)
+  #     if: runner.os == 'Windows'
+  #     run: |
+  #       [[ -f ${APPDATA}/terraform.rc ]] || exit 0
+
+  #   - name: Validate Teraform Credentials (Linux & macOS)
+  #     if: runner.os != 'Windows'
+  #     run: |
+  #       [[ -f ${HOME}/.terraformrc ]] || exit 0
+
+  # terraform-arguments:
+  #   name: 'Terraform Arguments'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+
+  #   - name: Check No Arguments
+  #     run: terraform || exit 0
+
+  #   - name: Check Single Argument
+  #     run: terraform help || exit 0
+
+  #   - name: Check Single Argument Hyphen
+  #     run: terraform -help
+
+  #   - name: Check Single Argument Double Hyphen
+  #     run: terraform --help
+
+  #   - name: Check Single Argument Subcommand
+  #     run: terraform fmt -check
+
+  #   - name: Check Multiple Arguments Subcommand
+  #     run: terraform fmt -check -list=true -no-color
+
+  # terraform-arguments-no-wrapper:
+  #   name: 'Terraform Arguments No Wrapper'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       terraform_wrapper: false
+
+  #   - name: Check No Arguments
+  #     run: terraform || exit 0
+
+  #   - name: Check Single Argument
+  #     run: terraform help || exit 0
+
+  #   - name: Check Single Argument Hyphen
+  #     run: terraform -help
+
+  #   - name: Check Single Argument Double Hyphen
+  #     run: terraform --help
+
+  #   - name: Check Single Argument Subcommand
+  #     run: terraform fmt -check
+
+  #   - name: Check Multiple Arguments Subcommand
+  #     run: terraform fmt -check -list=true -no-color
+
+  # terraform-run-local:
+  #   name: 'Terraform Run Local'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: ./.github/workflows/data/local
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+
+  #   - name: Terraform Init
+  #     run: terraform init
+
+  #   - name: Terraform Format
+  #     run: terraform fmt -check
+
+  #   - name: Terraform Plan
+  #     id: plan
+  #     run: terraform plan
+
+  #   - name: Print Terraform Plan
+  #     run: echo "${{ steps.plan.outputs.stdout }}"
+
+  # terraform-run-local-no-wrapper:
+  #   name: 'Terraform Run Local No Wrapper'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: ./.github/workflows/data/local
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       terraform_wrapper: false
+
+  #   - name: Terraform Init
+  #     run: terraform init
+
+  #   - name: Terraform Format
+  #     run: terraform fmt -check
+
+  #   - name: Terraform Plan
+  #     id: plan
+  #     run: terraform plan
+
+  # terraform-stdout-wrapper:
+  #   name: 'Terraform STDOUT'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: ./.github/workflows/data/local
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       terraform_wrapper: true
+
+  #   - name: Terraform Init
+  #     run: terraform init
+
+  #   - name: Terraform Format
+  #     run: terraform fmt -check
+
+  #   - name: Terraform Apply
+  #     id: apply
+  #     run: terraform apply -auto-approve
+
+  #   - name: Terraform Output to JQ
+  #     id: output
+  #     run: terraform output -json | jq '.pet.value'
+
+  # terraform-stdout-no-wrapper:
+  #   name: 'Terraform STDOUT No Wrapper'
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [ubuntu-latest, windows-latest, macos-latest]
+  #   defaults:
+  #     run:
+  #       shell: bash
+  #       working-directory: ./.github/workflows/data/local
+  #   steps:
+  #   - name: Checkout
+  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+  #   - name: Setup Terraform
+  #     uses: ./
+  #     with:
+  #       terraform_wrapper: false
+
+  #   - name: Terraform Init
+  #     run: terraform init
+
+  #   - name: Terraform Format
+  #     run: terraform fmt -check
+
+  #   - name: Terraform Apply
+  #     id: apply
+  #     run: terraform apply -auto-approve
+
+  #   - name: Terraform Output to JQ
+  #     id: output
+  #     run: terraform output -json | jq '.pet.value'
 
   # This test has an artificial delay for testing the streaming of STDOUT 
   terraform-wrapper-delayed-apply:

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -304,7 +304,6 @@ jobs:
       id: plan
       run: terraform plan
 
-
   terraform-stdout-wrapper:
     name: 'Terraform STDOUT'
     runs-on: ${{ matrix.os }}
@@ -370,3 +369,33 @@ jobs:
     - name: Terraform Output to JQ
       id: output
       run: terraform output -json | jq '.pet.value'
+
+  # This test has an artificial delay for testing the streaming of STDOUT 
+  terraform-wrapper-delayed-apply:
+    name: 'Terraform Delayed Apply'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/delay
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: true
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Apply
+      id: apply
+      run: terraform apply -auto-approve

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -11,364 +11,364 @@ defaults:
     shell: bash
 
 jobs:
-  # terraform-versions:
-  #   name: 'Terraform Versions'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       terraform-versions: [0.11.14, latest]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-  #     uses: ./
-  #     with:
-  #       terraform_version: ${{ matrix['terraform-versions'] }}
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     if: ${{ matrix['terraform-versions'] != 'latest' }}
-  #     run: terraform version | grep ${{ matrix['terraform-versions']}}
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     if: ${{ matrix['terraform-versions'] == 'latest' }}
-  #     run: terraform version | grep 'Terraform v'
-
-  # terraform-versions-no-wrapper:
-  #   name: 'Terraform Versions No Wrapper'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       terraform-versions: [0.11.14, latest]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-  #     uses: ./
-  #     with:
-  #       terraform_version: ${{ matrix['terraform-versions'] }}
-  #       terraform_wrapper: false
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     if: ${{ matrix['terraform-versions'] != 'latest' }}
-  #     run: terraform version | grep ${{ matrix['terraform-versions']}}
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     if: ${{ matrix['terraform-versions'] == 'latest' }}
-  #     run: terraform version | grep 'Terraform v'
-
-  # terraform-versions-constraints:
-  #   name: 'Terraform Versions Constraints'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       terraform-versions: [~0.12, 0.12.x, <0.13.0]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
-  #     uses: ./
-  #     with:
-  #       terraform_version: ${{ matrix['terraform-versions'] }}
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     run: terraform version | grep 'Terraform v0\.12'
-
-  # terraform-versions-constraints-no-wrapper:
-  #   name: 'Terraform Versions Constraints No Wrapper'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #       terraform-versions: [~0.12, 0.12.x, <0.13.0]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
-  #     uses: ./
-  #     with:
-  #       terraform_version: ${{ matrix['terraform-versions'] }}
-  #       terraform_wrapper: false
-
-  #   - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
-  #     run: terraform version | grep 'Terraform v0\.12'
-
-  # terraform-credentials-cloud:
-  #   name: 'Terraform Cloud Credentials'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   env:
-  #     TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
-
-  #   - name: Validate Terraform Credentials (Windows)
-  #     if: runner.os == 'Windows'
-  #     run: |
-  #       cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
-  #       cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  #   - name: Validate Teraform Credentials (Linux & macOS)
-  #     if: runner.os != 'Windows'
-  #     run: |
-  #       cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
-  #       cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  # terraform-credentials-enterprise:
-  #   name: 'Terraform Enterprise Credentials'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   env:
-  #     TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       cli_config_credentials_hostname: 'terraform.example.com'
-  #       cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
-
-  #   - name: Validate Terraform Credentials (Windows)
-  #     if: runner.os == 'Windows'
-  #     run: |
-  #       cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
-  #       cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  #   - name: Validate Teraform Credentials (Linux & macOS)
-  #     if: runner.os != 'Windows'
-  #     run: |
-  #       cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
-  #       cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
-
-  # terraform-credentials-none:
-  #   name: 'Terraform No Credentials'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-
-  #   - name: Validate Terraform Credentials (Windows)
-  #     if: runner.os == 'Windows'
-  #     run: |
-  #       [[ -f ${APPDATA}/terraform.rc ]] || exit 0
-
-  #   - name: Validate Teraform Credentials (Linux & macOS)
-  #     if: runner.os != 'Windows'
-  #     run: |
-  #       [[ -f ${HOME}/.terraformrc ]] || exit 0
-
-  # terraform-arguments:
-  #   name: 'Terraform Arguments'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-
-  #   - name: Check No Arguments
-  #     run: terraform || exit 0
-
-  #   - name: Check Single Argument
-  #     run: terraform help || exit 0
-
-  #   - name: Check Single Argument Hyphen
-  #     run: terraform -help
-
-  #   - name: Check Single Argument Double Hyphen
-  #     run: terraform --help
-
-  #   - name: Check Single Argument Subcommand
-  #     run: terraform fmt -check
-
-  #   - name: Check Multiple Arguments Subcommand
-  #     run: terraform fmt -check -list=true -no-color
-
-  # terraform-arguments-no-wrapper:
-  #   name: 'Terraform Arguments No Wrapper'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       terraform_wrapper: false
-
-  #   - name: Check No Arguments
-  #     run: terraform || exit 0
-
-  #   - name: Check Single Argument
-  #     run: terraform help || exit 0
-
-  #   - name: Check Single Argument Hyphen
-  #     run: terraform -help
-
-  #   - name: Check Single Argument Double Hyphen
-  #     run: terraform --help
-
-  #   - name: Check Single Argument Subcommand
-  #     run: terraform fmt -check
-
-  #   - name: Check Multiple Arguments Subcommand
-  #     run: terraform fmt -check -list=true -no-color
-
-  # terraform-run-local:
-  #   name: 'Terraform Run Local'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #       working-directory: ./.github/workflows/data/local
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-
-  #   - name: Terraform Init
-  #     run: terraform init
-
-  #   - name: Terraform Format
-  #     run: terraform fmt -check
-
-  #   - name: Terraform Plan
-  #     id: plan
-  #     run: terraform plan
-
-  #   - name: Print Terraform Plan
-  #     run: echo "${{ steps.plan.outputs.stdout }}"
-
-  # terraform-run-local-no-wrapper:
-  #   name: 'Terraform Run Local No Wrapper'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #       working-directory: ./.github/workflows/data/local
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       terraform_wrapper: false
-
-  #   - name: Terraform Init
-  #     run: terraform init
-
-  #   - name: Terraform Format
-  #     run: terraform fmt -check
-
-  #   - name: Terraform Plan
-  #     id: plan
-  #     run: terraform plan
-
-  # terraform-stdout-wrapper:
-  #   name: 'Terraform STDOUT'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #       working-directory: ./.github/workflows/data/local
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       terraform_wrapper: true
-
-  #   - name: Terraform Init
-  #     run: terraform init
-
-  #   - name: Terraform Format
-  #     run: terraform fmt -check
-
-  #   - name: Terraform Apply
-  #     id: apply
-  #     run: terraform apply -auto-approve
-
-  #   - name: Terraform Output to JQ
-  #     id: output
-  #     run: terraform output -json | jq '.pet.value'
-
-  # terraform-stdout-no-wrapper:
-  #   name: 'Terraform STDOUT No Wrapper'
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [ubuntu-latest, windows-latest, macos-latest]
-  #   defaults:
-  #     run:
-  #       shell: bash
-  #       working-directory: ./.github/workflows/data/local
-  #   steps:
-  #   - name: Checkout
-  #     uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-  #   - name: Setup Terraform
-  #     uses: ./
-  #     with:
-  #       terraform_wrapper: false
-
-  #   - name: Terraform Init
-  #     run: terraform init
-
-  #   - name: Terraform Format
-  #     run: terraform fmt -check
-
-  #   - name: Terraform Apply
-  #     id: apply
-  #     run: terraform apply -auto-approve
-
-  #   - name: Terraform Output to JQ
-  #     id: output
-  #     run: terraform output -json | jq '.pet.value'
+  terraform-versions:
+    name: 'Terraform Versions'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        terraform-versions: [0.11.14, latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] != 'latest' }}
+      run: terraform version | grep ${{ matrix['terraform-versions']}}
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] == 'latest' }}
+      run: terraform version | grep 'Terraform v'
+
+  terraform-versions-no-wrapper:
+    name: 'Terraform Versions No Wrapper'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        terraform-versions: [0.11.14, latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+        terraform_wrapper: false
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] != 'latest' }}
+      run: terraform version | grep ${{ matrix['terraform-versions']}}
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      if: ${{ matrix['terraform-versions'] == 'latest' }}
+      run: terraform version | grep 'Terraform v'
+
+  terraform-versions-constraints:
+    name: 'Terraform Versions Constraints'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        terraform-versions: [~0.12, 0.12.x, <0.13.0]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      run: terraform version | grep 'Terraform v0\.12'
+
+  terraform-versions-constraints-no-wrapper:
+    name: 'Terraform Versions Constraints No Wrapper'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+        terraform-versions: [~0.12, 0.12.x, <0.13.0]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform (no wrapper) - ${{ matrix['terraform-versions'] }}
+      uses: ./
+      with:
+        terraform_version: ${{ matrix['terraform-versions'] }}
+        terraform_wrapper: false
+
+    - name: Validate Teraform Version - ${{ matrix['terraform-versions'] }}
+      run: terraform version | grep 'Terraform v0\.12'
+
+  terraform-credentials-cloud:
+    name: 'Terraform Cloud Credentials'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cat ${APPDATA}/terraform.rc | grep 'credentials "app.terraform.io"'
+        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        cat ${HOME}/.terraformrc | grep 'credentials "app.terraform.io"'
+        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  terraform-credentials-enterprise:
+    name: 'Terraform Enterprise Credentials'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    env:
+      TF_CLOUD_API_TOKEN: 'XXXXXXXXXXXXXX.atlasv1.XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX'
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        cli_config_credentials_hostname: 'terraform.example.com'
+        cli_config_credentials_token: ${{ env.TF_CLOUD_API_TOKEN }}
+
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        cat ${APPDATA}/terraform.rc | grep 'credentials "terraform.example.com"'
+        cat ${APPDATA}/terraform.rc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        cat ${HOME}/.terraformrc | grep 'credentials "terraform.example.com"'
+        cat ${HOME}/.terraformrc | grep 'token = "${{ env.TF_CLOUD_API_TOKEN }}"'
+
+  terraform-credentials-none:
+    name: 'Terraform No Credentials'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+
+    - name: Validate Terraform Credentials (Windows)
+      if: runner.os == 'Windows'
+      run: |
+        [[ -f ${APPDATA}/terraform.rc ]] || exit 0
+
+    - name: Validate Teraform Credentials (Linux & macOS)
+      if: runner.os != 'Windows'
+      run: |
+        [[ -f ${HOME}/.terraformrc ]] || exit 0
+
+  terraform-arguments:
+    name: 'Terraform Arguments'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+
+    - name: Check No Arguments
+      run: terraform || exit 0
+
+    - name: Check Single Argument
+      run: terraform help || exit 0
+
+    - name: Check Single Argument Hyphen
+      run: terraform -help
+
+    - name: Check Single Argument Double Hyphen
+      run: terraform --help
+
+    - name: Check Single Argument Subcommand
+      run: terraform fmt -check
+
+    - name: Check Multiple Arguments Subcommand
+      run: terraform fmt -check -list=true -no-color
+
+  terraform-arguments-no-wrapper:
+    name: 'Terraform Arguments No Wrapper'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: false
+
+    - name: Check No Arguments
+      run: terraform || exit 0
+
+    - name: Check Single Argument
+      run: terraform help || exit 0
+
+    - name: Check Single Argument Hyphen
+      run: terraform -help
+
+    - name: Check Single Argument Double Hyphen
+      run: terraform --help
+
+    - name: Check Single Argument Subcommand
+      run: terraform fmt -check
+
+    - name: Check Multiple Arguments Subcommand
+      run: terraform fmt -check -list=true -no-color
+
+  terraform-run-local:
+    name: 'Terraform Run Local'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/local
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan
+
+    - name: Print Terraform Plan
+      run: echo "${{ steps.plan.outputs.stdout }}"
+
+  terraform-run-local-no-wrapper:
+    name: 'Terraform Run Local No Wrapper'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/local
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: false
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan
+
+  terraform-stdout-wrapper:
+    name: 'Terraform STDOUT'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/local
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: true
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Apply
+      id: apply
+      run: terraform apply -auto-approve
+
+    - name: Terraform Output to JQ
+      id: output
+      run: terraform output -json | jq '.pet.value'
+
+  terraform-stdout-no-wrapper:
+    name: 'Terraform STDOUT No Wrapper'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/local
+    steps:
+    - name: Checkout
+      uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+    - name: Setup Terraform
+      uses: ./
+      with:
+        terraform_wrapper: false
+
+    - name: Terraform Init
+      run: terraform init
+
+    - name: Terraform Format
+      run: terraform fmt -check
+
+    - name: Terraform Apply
+      id: apply
+      run: terraform apply -auto-approve
+
+    - name: Terraform Output to JQ
+      id: output
+      run: terraform output -json | jq '.pet.value'
 
   # This test has an artificial delay for testing the streaming of STDOUT 
   terraform-wrapper-delayed-apply:

--- a/dist/index1.js
+++ b/dist/index1.js
@@ -27599,13 +27599,18 @@ module.exports = {
  * console.log(listener.contents);
  */
 class OutputListener {
-  constructor () {
+  constructor (streamWriter) {
     this._buff = [];
+    this._streamWriter = streamWriter;
   }
 
   get listener () {
     const listen = function listen (data) {
       this._buff.push(data);
+
+      if (this._streamWriter) {
+        this._streamWriter.write(data);
+      }
     };
     return listen.bind(this);
   }
@@ -27946,9 +27951,9 @@ async function checkTerraform () {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
-  // Create listeners to receive output (in memory) as well
-  const stdout = new OutputListener();
-  const stderr = new OutputListener();
+  // Create listeners to receive output (in memory)
+  const stdout = new OutputListener(process.stdout);
+  const stderr = new OutputListener(process.stderr);
   const listeners = {
     stdout: stdout.listener,
     stderr: stderr.listener
@@ -27962,10 +27967,6 @@ async function checkTerraform () {
     silent: true // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
-
-  // Pass-through stdout/err as `exec` won't due to `silent: true` option
-  process.stdout.write(stdout.contents);
-  process.stderr.write(stderr.contents);
 
   // Set outputs, result, exitcode, and stderr
   core.setOutput('stdout', stdout.contents);

--- a/wrapper/lib/output-listener.js
+++ b/wrapper/lib/output-listener.js
@@ -20,13 +20,18 @@
  * console.log(listener.contents);
  */
 class OutputListener {
-  constructor () {
+  constructor (streamWriter) {
     this._buff = [];
+    this._streamWriter = streamWriter;
   }
 
   get listener () {
     const listen = function listen (data) {
       this._buff.push(data);
+
+      if (this._streamWriter) {
+        this._streamWriter.write(data);
+      }
     };
     return listen.bind(this);
   }

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -21,9 +21,9 @@ async function checkTerraform () {
   // This will fail if Terraform isn't found, which is what we want
   await checkTerraform();
 
-  // Create listeners to receive output (in memory) as well
-  const stdout = new OutputListener();
-  const stderr = new OutputListener();
+  // Create listeners to receive output (in memory)
+  const stdout = new OutputListener(process.stdout);
+  const stderr = new OutputListener(process.stderr);
   const listeners = {
     stdout: stdout.listener,
     stderr: stderr.listener
@@ -37,10 +37,6 @@ async function checkTerraform () {
     silent: true // avoid printing command in stdout: https://github.com/actions/toolkit/issues/649
   };
   const exitCode = await exec(pathToCLI, args, options);
-
-  // Pass-through stdout/err as `exec` won't due to `silent: true` option
-  process.stdout.write(stdout.contents);
-  process.stderr.write(stderr.contents);
 
   // Set outputs, result, exitcode, and stderr
   core.setOutput('stdout', stdout.contents);

--- a/wrapper/test/output-listener.test.js
+++ b/wrapper/test/output-listener.test.js
@@ -6,12 +6,31 @@
 const OutputListener = require('../lib/output-listener');
 
 describe('output-listener', () => {
-  it('receives and exposes data', () => {
+  it('receives and buffers data to .contents', () => {
     const listener = new OutputListener();
     const listen = listener.listener;
+
     listen(Buffer.from('foo'));
     listen(Buffer.from('bar'));
     listen(Buffer.from('baz'));
+
     expect(listener.contents).toEqual('foobarbaz');
+  });
+
+  it('receives and writes data to stream immediately', () => {
+    const mockWrite = jest.fn();
+    const listener = new OutputListener({ write: mockWrite });
+    const listen = listener.listener;
+
+    listen(Buffer.from('first write'));
+    expect(mockWrite.mock.lastCall[0]).toStrictEqual(Buffer.from('first write'));
+
+    listen(Buffer.from('second write'));
+    expect(mockWrite.mock.lastCall[0]).toStrictEqual(Buffer.from('second write'));
+
+    listen(Buffer.from('third write'));
+    expect(mockWrite.mock.lastCall[0]).toStrictEqual(Buffer.from('third write'));
+
+    expect(mockWrite).toBeCalledTimes(3);
   });
 });


### PR DESCRIPTION
Closes #395 
Closes #405

This PR restores the equivalent of the wrapper's original behavior to immediately output to STDOUT and STDERR when data is received. I've attached a demo video of the new delayed test.

## Context

Prior to #367, we relied on the [`@actions/exec`](https://github.com/actions/toolkit/tree/main/packages/exec#actionsexec) package to immediately write to STDOUT and STDERR (which is the default behavior of `silent: false`), see the [relevant underlying code](https://github.com/actions/toolkit/blob/81a73aba8bedd532f6eddcc41ed3a0fad8b1cfeb/packages/exec/src/toolrunner.ts#L450-L452).

Since we can't utilize the `@actions/exec` package's default behavior, due to the debug/command output being passed to the wrapper (https://github.com/actions/toolkit/issues/649), we can just update our original listener to just write the data as it's being buffered. Shout out to @dannystaple for the original thought!

## Demo

https://github.com/hashicorp/setup-terraform/assets/8650838/d0c6a832-a8d0-42e4-a764-384357897e29