### PR TITLE
bump `actions/github-script` from `@v6` to  `@v7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ steps:
   run: terraform plan -no-color
   continue-on-error: true
 
-- uses: actions/github-script@v6
+- uses: actions/github-script@v7
   if: github.event_name == 'pull_request'
   env:
     PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The `hashicorp/setup-terraform` action is a JavaScript action that sets up Terra
 
 - Downloading a specific version of Terraform CLI and adding it to the `PATH`.
 - Configuring the [Terraform CLI configuration file](https://www.terraform.io/docs/commands/cli-config.html) with a Terraform Cloud/Enterprise hostname and API token.
-- Installing a wrapper script to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
+- Installing a wrapper script to wrap subsequent calls of the `ter<img width="1552" alt="image" src="https://github.com/brignano/setup-terraform/assets/9291621/062a88ac-3341-4661-87ac-4bcfd450c0ef">
+raform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
 
 After you've used the action, subsequent steps in the same job can run arbitrary Terraform commands using [the GitHub Actions `run` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun). This allows most Terraform commands to work exactly like they do on your local command line.
 
@@ -179,7 +180,7 @@ steps:
   run: terraform plan -no-color
   continue-on-error: true
 
-- uses: actions/github-script@v6
+- uses: actions/github-script@v7
   if: github.event_name == 'pull_request'
   env:
     PLAN: "terraform\n${{ steps.plan.outputs.stdout }}"

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@ The `hashicorp/setup-terraform` action is a JavaScript action that sets up Terra
 
 - Downloading a specific version of Terraform CLI and adding it to the `PATH`.
 - Configuring the [Terraform CLI configuration file](https://www.terraform.io/docs/commands/cli-config.html) with a Terraform Cloud/Enterprise hostname and API token.
-- Installing a wrapper script to wrap subsequent calls of the `ter<img width="1552" alt="image" src="https://github.com/brignano/setup-terraform/assets/9291621/062a88ac-3341-4661-87ac-4bcfd450c0ef">
-raform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
+- Installing a wrapper script to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
 
 After you've used the action, subsequent steps in the same job can run arbitrary Terraform commands using [the GitHub Actions `run` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun). This allows most Terraform commands to work exactly like they do on your local command line.
 


### PR DESCRIPTION
Suggesting to bump `actions/github-script` from `@v6` to `@v7` to resolve the below warning,

<img width="1552" alt="image" src="https://github.com/hashicorp/setup-terraform/assets/9291621/9eb1bb6e-9152-4da7-840b-259072659a24">