### PR TITLE
Replacing "Terraform Cloud" with "HCP Terraform"

### DIFF
--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -100,7 +100,7 @@ jobs:
       run: terraform version | grep 'Terraform v0\.12'
 
   terraform-credentials-cloud:
-    name: 'Terraform Cloud Credentials'
+    name: 'HCP Terraform Credentials'
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 The `hashicorp/setup-terraform` action is a JavaScript action that sets up Terraform CLI in your GitHub Actions workflow by:
 
 - Downloading a specific version of Terraform CLI and adding it to the `PATH`.
-- Configuring the [Terraform CLI configuration file](https://www.terraform.io/docs/commands/cli-config.html) with a Terraform Cloud/Enterprise hostname and API token.
+- Configuring the [Terraform CLI configuration file](https://www.terraform.io/docs/commands/cli-config.html) with a HCP Terraform/Terraform Enterprise hostname and API token.
 - Installing a wrapper script to wrap subsequent calls of the `terraform` binary and expose its STDOUT, STDERR, and exit code as outputs named `stdout`, `stderr`, and `exitcode` respectively. (This can be optionally skipped if subsequent steps in the same job do not need to access the results of Terraform commands.)
 
 After you've used the action, subsequent steps in the same job can run arbitrary Terraform commands using [the GitHub Actions `run` syntax](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun). This allows most Terraform commands to work exactly like they do on your local command line.
@@ -31,7 +31,7 @@ steps:
     terraform_version: "1.1.7"
 ```
 
-Credentials for Terraform Cloud ([app.terraform.io](https://app.terraform.io/)) can be configured:
+Credentials for HCP Terraform ([app.terraform.io](https://app.terraform.io/)) can be configured:
 
 ```yaml
 steps:
@@ -242,9 +242,9 @@ steps:
 
 The action supports the following inputs:
 
-- `cli_config_credentials_hostname` - (optional) The hostname of a Terraform Cloud/Enterprise instance to
+- `cli_config_credentials_hostname` - (optional) The hostname of a HCP Terraform/Terraform Enterprise instance to
    place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.
-- `cli_config_credentials_token` - (optional) The API token for a Terraform Cloud/Enterprise instance to
+- `cli_config_credentials_token` - (optional) The API token for a HCP Terraform/Terraform Enterprise instance to
    place within the credentials block of the Terraform CLI configuration file.
 - `terraform_version` - (optional) The version of Terraform CLI to install. Instead of a full version string,
    you can also specify a constraint string (see [Semver Ranges](https://www.npmjs.com/package/semver#ranges)

--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,11 @@ description: 'Sets up Terraform CLI in your GitHub Actions workflow.'
 author: 'HashiCorp, Inc.'
 inputs:
   cli_config_credentials_hostname:
-    description: 'The hostname of a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.'
+    description: 'The hostname of a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file. Defaults to `app.terraform.io`.'
     default: 'app.terraform.io'
     required: false
   cli_config_credentials_token:
-    description: 'The API token for a Terraform Cloud/Enterprise instance to place within the credentials block of the Terraform CLI configuration file.'
+    description: 'The API token for a HCP Terraform/Terraform Enterprise instance to place within the credentials block of the Terraform CLI configuration file.'
     required: false
   terraform_version:
     description: 'The version of Terraform CLI to install. Instead of full version string you can also specify constraint string starting with "<" (for example `<1.13.0`) to install the latest version satisfying the constraint. A value of `latest` will install the latest version of Terraform CLI. Defaults to `latest`.'


### PR DESCRIPTION
Following rebranding, the term "Terraform Cloud" has been replaced with "HCP Terraform" throughout.