### PR TITLE
Fix exitcode bug introduced in PR/125

### DIFF
--- a/.github/workflows/data/failure/main.tf
+++ b/.github/workflows/data/failure/main.tf
@@ -1,0 +1,7 @@
+resource "random_pet" "pet" {
+  1invalid_key= ""
+}
+
+output "pet" {
+  value = random_pet.pet.id
+}

--- a/.github/workflows/setup-terraform.yml
+++ b/.github/workflows/setup-terraform.yml
@@ -270,7 +270,38 @@ jobs:
 
     - name: Terraform Plan
       id: plan
-      run: terraform plan
+      run: terraform plan -detailed-exitcode
+
+    - name: Print Terraform Plan
+      run: echo "${{ steps.plan.outputs.stdout }}"
+    
+  terraform-run-local-failures:
+    name: 'Terraform Run Local Failures'
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macos-latest]
+    defaults:
+      run:
+        shell: bash
+        working-directory: ./.github/workflows/data/failure
+    steps:
+    - name: Checkout
+      uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
+    - name: Setup Terraform
+      uses: ./
+
+      # coerce initial command exit code in order to verify it did fail
+    - name: Terraform Init
+      run: terraform init || $(exit 10) && $(exit 1) || [ $? -eq 10 ]
+
+    - name: Terraform Format
+      run: terraform fmt -check || $(exit 10) && $(exit 1) || [ $? -eq 10 ]
+
+    - name: Terraform Plan
+      id: plan
+      run: terraform plan -detailed-exitcode || $(exit 10) && $(exit 1) || [ $? -eq 10 ]
 
     - name: Print Terraform Plan
       run: echo "${{ steps.plan.outputs.stdout }}"

--- a/dist/index1.js
+++ b/dist/index1.js
@@ -27973,7 +27973,8 @@ async function checkTerraform () {
   core.setOutput('stderr', stderr.contents);
   core.setOutput('exitcode', exitCode.toString(10));
 
-  if (exitCode === 0 || exitCode === 2) {
+  const usingDetailedExitcode = args.filter(arg => arg.toLowerCase().endsWith('-detailed-exitcode')).length > 0;
+  if (exitCode === 0 || (exitCode === 2 && usingDetailedExitcode)) {
     // A exitCode of 0 is considered a success
     // An exitCode of 2 may be returned when the '-detailed-exitcode' option
     // is passed to plan. This denotes Success with non-empty

--- a/wrapper/terraform.js
+++ b/wrapper/terraform.js
@@ -43,7 +43,8 @@ async function checkTerraform () {
   core.setOutput('stderr', stderr.contents);
   core.setOutput('exitcode', exitCode.toString(10));
 
-  if (exitCode === 0 || exitCode === 2) {
+  const usingDetailedExitcode = args.filter(arg => arg.toLowerCase().endsWith('-detailed-exitcode')).length > 0;
+  if (exitCode === 0 || (exitCode === 2 && usingDetailedExitcode)) {
     // A exitCode of 0 is considered a success
     // An exitCode of 2 may be returned when the '-detailed-exitcode' option
     // is passed to plan. This denotes Success with non-empty


### PR DESCRIPTION
Due to https://github.com/hashicorp/setup-terraform/pull/125 any terraform exit code of `2` will be considered passing even when it is a valid failure.

For example, `terraform fmt` can return 0, 2, or 3.  (see https://github.com/hashicorp/terraform/blob/v1.9.3/internal/command/fmt.go#L96 )

- 0 - success
- 2 - has errors
- 3 - check is enabled and failed to pass check

The proposed solution in this PR is to verify that `-detailed-exitcode` argument was passed in.  Additional test scenarios were added to cover the original pull request and this change.
