### PR TITLE
Add "-input=false" to commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ steps:
 
 - name: Terraform Init
   id: init
-  run: terraform init
+  run: terraform init -input=false
 
 - name: Terraform Validate
   id: validate
@@ -108,7 +108,7 @@ steps:
 
 - name: Terraform Plan
   id: plan
-  run: terraform plan -no-color
+  run: terraform plan -no-color -input=false
   continue-on-error: true
 
 - uses: actions/github-script@v7
@@ -168,7 +168,7 @@ steps:
 
 - name: Terraform Init
   id: init
-  run: terraform init
+  run: terraform init -input=false
 
 - name: Terraform Validate
   id: validate
@@ -176,7 +176,7 @@ steps:
 
 - name: Terraform Plan
   id: plan
-  run: terraform plan -no-color
+  run: terraform plan -no-color -input=false
   continue-on-error: true
 
 - uses: actions/github-script@v7


### PR DESCRIPTION
If any terraform CLI command requires input, the pipeline will wait indefinitely.
The solution is to add `-input=false` to every applicable terraform command, like so:

```bash
terraform plan -out=tfplan -input=false
```

See [the docs](https://developer.hashicorp.com/terraform/tutorials/automation/automate-terraform#automated-terraform-cli-workflow) for more info.

I think the Readme file here should reflect that. There was a PR to fix the Readme file: #60. 
The discussion there suggested a solution to use an environment variable to disable requests for input, but it doesn't solve this problem since it has a different purpose ([see here](https://developer.hashicorp.com/terraform/cli/config/environment-variables#tf_in_automation))

Fixes #150 