### PR TITLE
Fix running wrapper on self-hosted runners

### DIFF
--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -87,7 +87,7 @@ async function installWrapper (pathToCLI) {
     wrapperContent[0] = `#!${process.argv[0]}`;
 
     core.debug(`Writing updated wrapper to ${target}.`);
-    await fs.writeFile(target, wrapperContent.join('\n'));
+    await fs.writeFile(target, wrapperContent.join('\n'), { mode: 0o755 });
   } catch (e) {
     core.error(`Unable to copy ${source} to ${target}.`);
     throw e;

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -81,8 +81,13 @@ async function installWrapper (pathToCLI) {
   try {
     source = path.resolve([__dirname, '..', 'wrapper', 'dist', 'index.js'].join(path.sep));
     target = [pathToCLI, 'terraform'].join(path.sep);
-    core.debug(`Copying ${source} to ${target}.`);
-    await io.cp(source, target);
+
+    core.debug(`Reading wrapper from ${source} and updating shebang.`);
+    const wrapperContent = (await fs.readFile(source, 'utf8')).split('\n');
+    wrapperContent[0] = `#!${process.argv[0]}`;
+
+    core.debug(`Writing updated wrapper to ${target}.`);
+    await fs.writeFile(target, wrapperContent.join('\n'));
   } catch (e) {
     core.error(`Unable to copy ${source} to ${target}.`);
     throw e;

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -602,7 +602,7 @@ describe('Setup Terraform', () => {
 
     expect(ioMv).toHaveBeenCalledWith(`file${path.sep}terraform`, `file${path.sep}terraform-bin`);
     expect(fsReadFile).toHaveBeenCalledWith(wrapperPath, 'utf8');
-    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String));
+    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String), { mode: 0o755 });
   });
 
   test('installs wrapper on windows', async () => {
@@ -660,6 +660,6 @@ describe('Setup Terraform', () => {
 
     expect(ioMv).toHaveBeenCalledWith(`file${path.sep}terraform.exe`, `file${path.sep}terraform-bin.exe`);
     expect(fsReadFile).toHaveBeenCalledWith(wrapperPath, 'utf8');
-    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String));
+    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String), { mode: 0o755 });
   });
 });

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -27,6 +27,9 @@ const setup = require('../lib/setup-terraform');
 // core.error = jest
 //   .fn(console.error);
 
+const fsReadFileImplementation = fs.readFile;
+const fsWriteFileImplementation = fs.writeFile;
+
 describe('Setup Terraform', () => {
   const HOME = process.env.HOME;
   const APPDATA = process.env.APPDATA;
@@ -553,8 +556,20 @@ describe('Setup Terraform', () => {
 
     const ioMv = jest.spyOn(io, 'mv')
       .mockImplementation(() => {});
-    const ioCp = jest.spyOn(io, 'cp')
-      .mockImplementation(() => {});
+    const fsReadFile = jest.spyOn(fs, 'readFile').mockImplementation((...args) => {
+      if (args[0] === wrapperPath) {
+        return Promise.resolve('');
+      } else {
+        return fsReadFileImplementation(...args);
+      }
+    });
+    const fsWriteFile = jest.spyOn(fs, 'writeFile').mockImplementation((...args) => {
+      if (args[0] === `file${path.sep}terraform`) {
+        return Promise.resolve();
+      } else {
+        return fsWriteFileImplementation(...args);
+      }
+    });
 
     core.getInput = jest
       .fn()
@@ -586,7 +601,8 @@ describe('Setup Terraform', () => {
     await setup();
 
     expect(ioMv).toHaveBeenCalledWith(`file${path.sep}terraform`, `file${path.sep}terraform-bin`);
-    expect(ioCp).toHaveBeenCalledWith(wrapperPath, `file${path.sep}terraform`);
+    expect(fsReadFile).toHaveBeenCalledWith(wrapperPath, 'utf8');
+    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String));
   });
 
   test('installs wrapper on windows', async () => {
@@ -597,8 +613,21 @@ describe('Setup Terraform', () => {
 
     const ioMv = jest.spyOn(io, 'mv')
       .mockImplementation(() => {});
-    const ioCp = jest.spyOn(io, 'cp')
-      .mockImplementation(() => {});
+    const fsReadFileImplementation = fs.readFile;
+    const fsReadFile = jest.spyOn(fs, 'readFile').mockImplementation((...args) => {
+      if (args[0] === wrapperPath) {
+        return Promise.resolve('');
+      } else {
+        return fsReadFileImplementation(...args);
+      }
+    });
+    const fsWriteFile = jest.spyOn(fs, 'writeFile').mockImplementation((...args) => {
+      if (args[0] === `file${path.sep}terraform`) {
+        return Promise.resolve();
+      } else {
+        return fsWriteFileImplementation(...args);
+      }
+    });
 
     core.getInput = jest
       .fn()
@@ -630,6 +659,7 @@ describe('Setup Terraform', () => {
     await setup();
 
     expect(ioMv).toHaveBeenCalledWith(`file${path.sep}terraform.exe`, `file${path.sep}terraform-bin.exe`);
-    expect(ioCp).toHaveBeenCalledWith(wrapperPath, `file${path.sep}terraform`);
+    expect(fsReadFile).toHaveBeenCalledWith(wrapperPath, 'utf8');
+    expect(fsWriteFile).toHaveBeenCalledWith(`file${path.sep}terraform`, expect.any(String));
   });
 });


### PR DESCRIPTION
## Related Issue

Fixes #84

## Description

On a self-hosted runner, the `node` binary isn't in the path, making the wrapper run fail.

In the related issue, there are several workarounds:

- Adding the node binary to the path
- Setting up the node before running Terraform

In my company, we have a shared workflow(using this action) that might run on GitHub-hosted runners or self-hosted runners, and I was hesitant to add a hack.

Looking for a solution I thought it would be nice to run the wrapper using the same node binary as this action does, so I decided to patch the first line of the wrapper to replace the `#!/usr/bin/env node` shebang with the full path of action node which can be found at `process.argv[0]`.

I tested on my fork using a linux runners (GitHub and self-hosted), and it worked, but I'm unsure what will happen on Windows.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [ ] If a change needs to be reverted, we will roll out an update to the code within 7 days.


