### PR TITLE
fix: extract 3 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,8 +55,10 @@ jobs:
           git config --global user.email "${{ vars.TF_DEVEX_CI_COMMIT_EMAIL }}"
           git add .
           git commit -a -m "Update changelog"
-          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${TF_DEVEX_COMMIT_GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
+        env:
+          TF_DEVEX_COMMIT_GITHUB_TOKEN: ${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}
   update-package-version:
     needs: changelog
     runs-on: ubuntu-latest
@@ -84,8 +86,10 @@ jobs:
           git config --global user.email "${{ vars.TF_DEVEX_CI_COMMIT_EMAIL }}"
           git add .
           git commit -a -m "Update package version"
-          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${TF_DEVEX_COMMIT_GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
 
+        env:
+          TF_DEVEX_COMMIT_GITHUB_TOKEN: ${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}
   release-tag:
     needs: [ update-package-version, major-version ]
     runs-on: ubuntu-latest
@@ -108,9 +112,11 @@ jobs:
 
           git tag "${{ inputs.versionNumber }}"
           git tag -f "${{ needs.major-version.outputs.version }}"
-          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" "${{ inputs.versionNumber }}"
-          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}@github.com/${{ github.repository }}.git" -f "${{ needs.major-version.outputs.version }}"
+          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${TF_DEVEX_COMMIT_GITHUB_TOKEN}@github.com/${{ github.repository }}.git" "${{ inputs.versionNumber }}"
+          git push "https://${{ vars.TF_DEVEX_CI_COMMIT_AUTHOR }}:${TF_DEVEX_COMMIT_GITHUB_TOKEN}@github.com/${{ github.repository }}.git" -f "${{ needs.major-version.outputs.version }}"
 
+        env:
+          TF_DEVEX_COMMIT_GITHUB_TOKEN: ${{ secrets.TF_DEVEX_COMMIT_GITHUB_TOKEN }}
   release:
     needs: [ changelog-version, release-tag ]
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

This PR hardens CI/CD workflows against supply chain attacks by extracting 3 secrets from `run:` blocks into `env:` mappings.

## Summary

This PR hardens your CI/CD workflows against supply chain attacks by extracting unsafe expressions from `run:` blocks into `env:` mappings.

| Rule | Severity | File | Fix |
|------|----------|------|-----|
| RGS-008 | high | `release.yml` | Extracted 3 `TF_DEVEX_COMMIT_GITHUB_TOKEN` secrets to env vars |

## Why this PR

I've been scanning the top 50,000 GitHub repositories for CI/CD pipeline vulnerabilities over the last 5 weeks as part of an ongoing research effort into the supply chain attack campaign that started with tj-actions in March and has escalated through multiple phases since.

You may notice that I have opened up a lot of PRs - don't take that as a negative. I've been working around the clock on this and monitoring all comms. It may take me an hour or two to get back to a comment you leave.

## How to verify

Every change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-008): Moves `${{ secrets.* }}` from `run:` blocks into `env:` mappings, preventing shell injection
- No workflow logic, triggers, or permissions are modified

We've had 22 merges so far including next.js, keras, webpack, svelte, apache/superset, and excalidraw. I created a tool called [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) to assist in my research - it does mechanical, non-AI fixes to reduce hallucinations to zero and produce consistent fixes. If you would like to scan it yourself to validate my work, feel free.

Happy to answer any questions - I'm monitoring comms on every PR.

\- Chris Nyhuis ([dagecko](https://github.com/dagecko))

### PCI review checklist
- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
  - Revert plan: revert this PR. All changes are additive env mappings.
- [x] If applicable, I've documented the impact of any changes to security controls.
  - Impact: improves security by preventing shell injection of secrets.