### PR TITLE
chore: update CI node version from 20 to 24

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -11,12 +11,12 @@ jobs:
     name: Check dist/ directory
     uses: actions/reusable-workflows/.github/workflows/check-dist.yml@95d9656793415e47f574f7967f3850ea3bf5a7ed
     with:
-      node-version: 20.x
+      node-version: 24.x
       node-caching: npm
 
   test:
     name: Test
     uses: actions/reusable-workflows/.github/workflows/basic-validation.yml@95d9656793415e47f574f7967f3850ea3bf5a7ed
     with:
-      node-version: 20.x
+      node-version: 24.x
       node-caching: npm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
-          node-version: 20
+          node-version: 24
       - name: Update package version
         run: npm version "${{ inputs.versionNumber }}" --git-tag-version false
       - name: Git push


### PR DESCRIPTION
## Related Issue

Fixes #543 

## Description
Update all references from `node-version: 20` to `node-version: 24` in:
- `.github/workflows/continuous-integration.yml`
- `.github/workflows/release.yml`

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

- [X] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
