### PR TITLE
Verify downloaded Terraform archive against the published SHA256SUMS

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260612-000000.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260612-000000.yaml
@@ -1,0 +1,5 @@
+kind: ENHANCEMENTS
+body: Verify the downloaded Terraform archive against the PGP-signed SHA256SUMS published by HashiCorp before extracting it
+time: 2026-06-12T00:00:00Z
+custom:
+  Issue: "556"

--- a/dist/index.js
+++ b/dist/index.js
@@ -40,9 +40,17 @@ function mapOS (os) {
   return mappings[os] || os;
 }
 
-async function downloadCLI (url) {
+async function downloadCLI (url, release, buildName) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+
+  // Verify the integrity of the downloaded archive against the PGP-signed
+  // SHA256SUMS that HashiCorp publishes for the release before extracting and
+  // running it. This is defense-in-depth on top of the TLS-protected download:
+  // it fails the install if a mirror, CDN, or resolved URL ever serves bytes
+  // that do not match the signed checksum.
+  core.debug(`Verifying ${buildName} against the published SHA256SUMS`);
+  await release.verify(pathToCLIZip, buildName);
 
   let pathToCLI = '';
 
@@ -158,7 +166,7 @@ async function run () {
     }
 
     // Download requested version
-    const pathToCLI = await downloadCLI(build.url);
+    const pathToCLI = await downloadCLI(build.url, release, build.filename);
 
     // Install our wrapper
     if (wrapper) {

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -34,9 +34,17 @@ function mapOS (os) {
   return mappings[os] || os;
 }
 
-async function downloadCLI (url) {
+async function downloadCLI (url, release, buildName) {
   core.debug(`Downloading Terraform CLI from ${url}`);
   const pathToCLIZip = await tc.downloadTool(url);
+
+  // Verify the integrity of the downloaded archive against the PGP-signed
+  // SHA256SUMS that HashiCorp publishes for the release before extracting and
+  // running it. This is defense-in-depth on top of the TLS-protected download:
+  // it fails the install if a mirror, CDN, or resolved URL ever serves bytes
+  // that do not match the signed checksum.
+  core.debug(`Verifying ${buildName} against the published SHA256SUMS`);
+  await release.verify(pathToCLIZip, buildName);
 
   let pathToCLI = '';
 
@@ -152,7 +160,7 @@ async function run () {
     }
 
     // Download requested version
-    const pathToCLI = await downloadCLI(build.url);
+    const pathToCLI = await downloadCLI(build.url, release, build.filename);
 
     // Install our wrapper
     if (wrapper) {

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -17,6 +17,7 @@ const io = require('@actions/io');
 const core = require('@actions/core');
 const tc = require('@actions/tool-cache');
 const nock = require('nock');
+const releases = require('@hashicorp/js-releases');
 
 const json = require('./index.json');
 const setup = require('../lib/setup-terraform');
@@ -34,9 +35,19 @@ describe('Setup Terraform', () => {
   beforeEach(() => {
     process.env.HOME = '/tmp/asdf';
     process.env.APPDATA = '/tmp/asdf';
+
+    // Stub the checksum/signature verification by default. The real
+    // implementation streams the downloaded zip and fetches the signed
+    // SHA256SUMS over the network, neither of which exists under the mocked
+    // download in these tests. Individual tests override this to exercise the
+    // verification path.
+    jest
+      .spyOn(releases.Release.prototype, 'verify')
+      .mockResolvedValue();
   });
 
   afterEach(async () => {
+    jest.restoreAllMocks();
     await io.rmRF(process.env.HOME);
     process.env.HOME = HOME;
     process.env.APPDATA = APPDATA;
@@ -631,5 +642,78 @@ describe('Setup Terraform', () => {
 
     expect(ioMv).toHaveBeenCalledWith(`file${path.sep}terraform.exe`, `file${path.sep}terraform-bin.exe`);
     expect(ioCp).toHaveBeenCalledWith(wrapperPath, `file${path.sep}terraform`);
+  });
+
+  test('verifies the downloaded archive against the published SHA256SUMS', async () => {
+    const version = '0.1.1';
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await setup();
+
+    // The downloaded zip is verified against the platform-specific build name
+    // before it is extracted and added to the path.
+    expect(releases.Release.prototype.verify).toHaveBeenCalledWith('file.zip', 'terraform_0.1.1_linux_amd64.zip');
+    expect(core.addPath).toHaveBeenCalled();
+  });
+
+  test('fails when the downloaded archive does not match the published SHA256SUMS', async () => {
+    const version = '0.1.1';
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    releases.Release.prototype.verify
+      .mockReset()
+      .mockRejectedValueOnce(new Error('Install error: SHA sum for terraform_0.1.1_linux_amd64.zip does not match.'));
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await expect(setup()).rejects.toThrow('does not match');
+
+    // A failed verification must stop the install before the archive is
+    // extracted, so the unverified binary is never placed on the path.
+    expect(tc.extractZip).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Related Issue

Fixes #556

## Description

`setup-terraform` downloaded the Terraform release zip and extracted it without verifying its integrity — TLS protected the bytes in transit, but the action took no defense-in-depth step beyond that, so a compromised mirror, CDN incident, or any future change to the resolved URL could land an arbitrary binary on every runner.

This adds a single verification step in `downloadCLI`, right after the download and before extraction:

```js
await release.verify(pathToCLIZip, build.filename);
```

`@hashicorp/js-releases` (already a dependency) exposes `Release.verify(pkg, buildName)`, which fetches the release's `terraform_<v>_SHA256SUMS`, verifies its detached PGP signature against the embedded HashiCorp release key, then compares the SHA-256 of the downloaded archive against the signed checksum — failing the install loudly on any mismatch. Reusing this existing, already-vendored method keeps the change minimal and covers both the SHA-256 check and the stronger signature-verification path described in the issue, with no new input or behavior toggle.

The Apache Software Foundation flags every release of this action in its [approved-actions allowlist](https://github.com/apache/infrastructure-actions) because of this missing check (see #556); this closes that gap so future version bumps no longer require a manual security re-review.

## Validation

- `npm test` — semistandard clean, 19/19 jest pass (added 2 tests: verification is invoked with the platform build name; a checksum mismatch aborts before extraction).
- `npm run build` — `dist/` rebuilt; diff is limited to the logical change.
- Added a changie `ENHANCEMENTS` fragment for #556.

## Rollback Plan

- [x] If a change needs to be reverted, we will roll out an update to the code within 7 days.

## Changes to Security Controls

Yes. This adds an integrity control to the install path: the downloaded Terraform archive is now verified against HashiCorp's PGP-signed `SHA256SUMS` before it is extracted or placed on the `PATH`. A failed or missing verification aborts the install. No logging, access-control, or credential-handling behavior changes.
