### PR TITLE
fix: check tool cache before downloading Terraform

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -157,8 +157,16 @@ async function run () {
       throw new Error(`Terraform version ${version} not available for ${platform} and ${arch}`);
     }
 
-    // Download requested version
-    const pathToCLI = await downloadCLI(build.url);
+    // Check tool cache first
+    let pathToCLI = tc.find('terraform', release.version, arch);
+
+    if (!pathToCLI) {
+      // Download requested version
+      const downloadedPath = await downloadCLI(build.url);
+
+      // Cache for reuse across runs
+      pathToCLI = await tc.cacheDir(downloadedPath, 'terraform', release.version, arch);
+    }
 
     // Install our wrapper
     if (wrapper) {


### PR DESCRIPTION
Without a tc.find() guard the action re-downloads Terraform on every run. Add tc.find() check before downloading; cache with tc.cacheDir() after first download.

Fixes https://github.com/hashicorp/setup-terraform/issues/510

tested locally
_first run_
```
trigger: setup-terraform {"terraform_version": "1.9.8"} (image=node:24, entry=dist/index.js)
::debug::Finding releases for Terraform version 1.9.8
::debug::Getting build for Terraform version 1.9.8: linux arm64
::debug::isExplicit: 1.9.8
::debug::explicit? true
::debug::checking cache: /opt/hostedtoolcache/terraform/1.9.8/arm64
::debug::not found
::debug::Downloading Terraform CLI from https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_arm64.zip
::debug::Downloading https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_arm64.zip
::debug::Destination /tmp/runner-temp/39193455-5fa1-42d3-9138-738beb4dad15
::debug::download complete
::debug::Extracting Terraform CLI zip file
[command]/usr/bin/unzip -o -q /tmp/runner-temp/39193455-5fa1-42d3-9138-738beb4dad15
::debug::Terraform CLI path is /tmp/runner-temp/fe73a3f6-3656-4a32-8d72-397a35642aad.
::debug::Caching tool terraform 1.9.8 arm64
::debug::source dir: /tmp/runner-temp/fe73a3f6-3656-4a32-8d72-397a35642aad
::debug::destination /opt/hostedtoolcache/terraform/1.9.8/arm64
::debug::finished caching tool
::debug::Moving /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform to /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform-bin.
::debug::Copying /actions/setup-terraform/dist/index1.js to /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform.
::set-env name=TERRAFORM_CLI_PATH::/opt/hostedtoolcache/terraform/1.9.8/arm64
::add-path::/opt/hostedtoolcache/terraform/1.9.8/arm64
```

_second run_
```
trigger: setup-terraform {"terraform_version": "1.9.8"} (image=node:24, entry=dist/index.js)
::debug::Finding releases for Terraform version 1.9.8
::debug::Getting build for Terraform version 1.9.8: linux arm64
::debug::isExplicit: 1.9.8
::debug::explicit? true
::debug::checking cache: /opt/hostedtoolcache/terraform/1.9.8/arm64
::debug::Found tool in cache terraform 1.9.8 arm64
::debug::Moving /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform to /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform-bin.
::debug::Copying /actions/setup-terraform/dist/index1.js to /opt/hostedtoolcache/terraform/1.9.8/arm64/terraform.
::set-env name=TERRAFORM_CLI_PATH::/opt/hostedtoolcache/terraform/1.9.8/arm64
::add-path::/opt/hostedtoolcache/terraform/1.9.8/arm64
```

