### PR TITLE
fix: preserve existing Terraform CLI config

### DIFF
--- a/.changes/unreleased/BUG FIXES-20260808-035912.yaml
+++ b/.changes/unreleased/BUG FIXES-20260808-035912.yaml
@@ -1,0 +1,5 @@
+kind: BUG FIXES
+body: Preserve an existing Terraform CLI configuration file instead of overwriting it when adding credentials
+time: 2026-08-08T03:59:12.000000+00:00
+custom:
+    Issue: "428"

--- a/dist/index.js
+++ b/dist/index.js
@@ -123,6 +123,34 @@ credentials "${credentialsHostname}" {
   core.debug(`Creating ${credsFolder}`);
   await io.mkdirP(credsFolder);
 
+  // Preserve an existing CLI configuration file, only adding the
+  // credentials block when one for the hostname does not already exist.
+  // https://github.com/hashicorp/setup-terraform/issues/428
+  let existing = '';
+  try {
+    existing = await fs.readFile(credsFile, { encoding: 'utf8' });
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (existing) {
+    const hasCredentials = existing.split('\n').some((line) => {
+      const trimmed = line.trim();
+      return trimmed.startsWith('credentials') && trimmed.includes(`"${credentialsHostname}"`);
+    });
+    if (hasCredentials) {
+      core.debug(`Credentials for ${credentialsHostname} already exist in ${credsFile}. Skipping.`);
+      return;
+    }
+
+    core.debug(`Adding credentials to ${credsFile}`);
+    const separator = existing.endsWith('\n') ? '' : '\n';
+    await fs.writeFile(credsFile, `${existing}${separator}\n${creds}\n`);
+    return;
+  }
+
   core.debug(`Adding credentials to ${credsFile}`);
   await fs.writeFile(credsFile, creds);
 }

--- a/lib/setup-terraform.js
+++ b/lib/setup-terraform.js
@@ -117,6 +117,34 @@ credentials "${credentialsHostname}" {
   core.debug(`Creating ${credsFolder}`);
   await io.mkdirP(credsFolder);
 
+  // Preserve an existing CLI configuration file, only adding the
+  // credentials block when one for the hostname does not already exist.
+  // https://github.com/hashicorp/setup-terraform/issues/428
+  let existing = '';
+  try {
+    existing = await fs.readFile(credsFile, { encoding: 'utf8' });
+  } catch (error) {
+    if (error.code !== 'ENOENT') {
+      throw error;
+    }
+  }
+
+  if (existing) {
+    const hasCredentials = existing.split('\n').some((line) => {
+      const trimmed = line.trim();
+      return trimmed.startsWith('credentials') && trimmed.includes(`"${credentialsHostname}"`);
+    });
+    if (hasCredentials) {
+      core.debug(`Credentials for ${credentialsHostname} already exist in ${credsFile}. Skipping.`);
+      return;
+    }
+
+    core.debug(`Adding credentials to ${credsFile}`);
+    const separator = existing.endsWith('\n') ? '' : '\n';
+    await fs.writeFile(credsFile, `${existing}${separator}\n${creds}\n`);
+    return;
+  }
+
   core.debug(`Adding credentials to ${credsFile}`);
   await fs.writeFile(credsFile, creds);
 }

--- a/test/setup-terraform.test.js
+++ b/test/setup-terraform.test.js
@@ -425,6 +425,188 @@ describe('Setup Terraform', () => {
     expect(creds.indexOf(credentialsToken)).toBeGreaterThan(-1);
   });
 
+  test('writes exactly the credentials block to a fresh config file', async () => {
+    const version = '0.1.1';
+    const credentialsHostname = 'app.terraform.io';
+    const credentialsToken = 'asdfjkl';
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version)
+      .mockReturnValueOnce(credentialsHostname)
+      .mockReturnValueOnce(credentialsToken);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await setup();
+
+    const creds = await fs.readFile(`${process.env.HOME}/.terraformrc`, { encoding: 'utf8' });
+    expect(creds).toEqual(`credentials "${credentialsHostname}" {
+  token = "${credentialsToken}"
+}`);
+  });
+
+  test('preserves an existing config file when adding credentials for a different hostname', async () => {
+    const version = '0.1.1';
+    const credentialsHostname = 'app.terraform.io';
+    const credentialsToken = 'asdfjkl';
+
+    const existingConfig = `plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"
+credentials "terraform.example.com" {
+  token = "existing-token"
+}`;
+    await fs.mkdir(process.env.HOME, { recursive: true });
+    await fs.writeFile(`${process.env.HOME}/.terraformrc`, existingConfig);
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version)
+      .mockReturnValueOnce(credentialsHostname)
+      .mockReturnValueOnce(credentialsToken);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await setup();
+
+    const creds = await fs.readFile(`${process.env.HOME}/.terraformrc`, { encoding: 'utf8' });
+    // the entire existing content is preserved as a prefix
+    expect(creds.indexOf(existingConfig)).toBe(0);
+    // new credentials block was added
+    expect(creds.indexOf(credentialsHostname)).toBeGreaterThan(-1);
+    expect(creds.indexOf(credentialsToken)).toBeGreaterThan(-1);
+  });
+
+  test('does not overwrite credentials for the same hostname', async () => {
+    const version = '0.1.1';
+    const credentialsHostname = 'app.terraform.io';
+    const credentialsToken = 'asdfjkl';
+
+    const existingConfig = `credentials "${credentialsHostname}"
+{
+  token = "existing-token"
+}`;
+    await fs.mkdir(process.env.HOME, { recursive: true });
+    await fs.writeFile(`${process.env.HOME}/.terraformrc`, existingConfig);
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version)
+      .mockReturnValueOnce(credentialsHostname)
+      .mockReturnValueOnce(credentialsToken);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await setup();
+
+    const creds = await fs.readFile(`${process.env.HOME}/.terraformrc`, { encoding: 'utf8' });
+    // existing config file is left untouched and still contains a single credentials block
+    expect(creds).toEqual(existingConfig);
+    expect(creds.indexOf(credentialsToken)).toBe(-1);
+    expect(creds.split(`credentials "${credentialsHostname}"`).length).toBe(2);
+  });
+
+  test('preserves an existing config file overridden with TF_CLI_CONFIG_FILE', async () => {
+    const version = '0.1.1';
+    const credentialsHostname = 'app.terraform.io';
+    const credentialsToken = 'asdfjkl';
+
+    const configPath = `${process.env.HOME}/terraformrc.tfrc`;
+    process.env.TF_CLI_CONFIG_FILE = configPath;
+    const existingConfig = 'plugin_cache_dir = "$HOME/.terraform.d/plugin-cache"\n';
+    await fs.mkdir(process.env.HOME, { recursive: true });
+    await fs.writeFile(configPath, existingConfig);
+
+    core.getInput = jest
+      .fn()
+      .mockReturnValueOnce(version)
+      .mockReturnValueOnce(credentialsHostname)
+      .mockReturnValueOnce(credentialsToken);
+
+    tc.downloadTool = jest
+      .fn()
+      .mockReturnValueOnce('file.zip');
+
+    tc.extractZip = jest
+      .fn()
+      .mockReturnValueOnce('file');
+
+    os.platform = jest
+      .fn()
+      .mockReturnValue('linux');
+
+    os.arch = jest
+      .fn()
+      .mockReturnValue('amd64');
+
+    nock('https://releases.hashicorp.com')
+      .get('/terraform/index.json')
+      .reply(200, json);
+
+    await setup();
+
+    const creds = await fs.readFile(configPath, { encoding: 'utf8' });
+    // existing content is preserved and credentials were appended
+    expect(creds.indexOf(existingConfig)).toBe(0);
+    expect(creds.indexOf(credentialsHostname)).toBeGreaterThan(-1);
+    expect(creds.indexOf(credentialsToken)).toBeGreaterThan(-1);
+
+    delete process.env.TF_CLI_CONFIG_FILE;
+  });
+
   test('fails when metadata cannot be downloaded', async () => {
     const version = 'latest';
     const credentialsHostname = 'app.terraform.io';


### PR DESCRIPTION
### What was broken

`addCredentials()` in `lib/setup-terraform.js` used `fs.writeFile()` to write the credentials block, overwriting any pre-existing Terraform CLI configuration file (`~/.terraformrc`, `%APPDATA%/terraform.rc`, or the path set via `TF_CLI_CONFIG_FILE`). Existing `plugin_cache_dir`, provider mirrors, other credentials blocks, and any other user configuration were silently destroyed.

See #428 and #269.

### What changed

- The existing config file is read before writing.
- Only `ENOENT` is treated as "file does not exist"; all other read errors are propagated.
- If a credentials block for the requested hostname already exists, the file is left untouched. This is intentionally **add-if-absent** semantics: the action never rotates or replaces an existing token.
- If the file exists without a block for that hostname, all existing content is preserved byte-for-byte and the credentials block is appended.
- If the file does not exist, behavior is identical to before.
- No HCL parsing, no regex rewriting, no new dependencies, no input changes.

### Validation

- `npm test` (semistandard + jest): 21/21 passing
- 4 new tests: fresh file (exact output), different hostname (entire config preserved as prefix), same hostname (untouched, no duplicate), `TF_CLI_CONFIG_FILE` override
- `npm run build`; `dist/index.js` regenerated (required by check-dist)
- Changelog fragment added under `.changes/unreleased/`

### Note

If credentials for the same hostname already exist, the supplied token is not applied; delete the block/file to re-provision credentials.